### PR TITLE
Revisions/version 1.0.1.0

### DIFF
--- a/Documents/Artillery Mage (NPC).gca5
+++ b/Documents/Artillery Mage (NPC).gca5
@@ -3,13 +3,13 @@
   <character>
     <author>
       <name>GURPS Character Assistant</name>
-      <version>GCA5Engine, Version=5.0.197.0</version>
+      <version>GCA5Engine, Version=5.0.202.0</version>
       <copyright>Program code is copyright © 1995-2022 by Armin D. Sykes. All data files, graphics, and other GURPS-specific content is copyright © 2005 and other years by Steve Jackson Games Incorporated. GURPS and the all-seeing pyramid are registered trademarks of Steve Jackson Games Incorporated. All rights reserved.</copyright>
-      <datecreated>Sunday, September 11, 2022</datecreated>
+      <datecreated>Saturday, November 12, 2022</datecreated>
     </author>
     <system>
       <version>5</version>
-      <lastkey>13364</lastkey>
+      <lastkey>13366</lastkey>
     </system>
     <library>
       <name>%user%\Greyhawk.gds</name>
@@ -183,6 +183,8 @@
       <charactersheet>%user%\phoenix.gcs</charactersheet>
       <altcharactersheet>%user%\text layout.gcs</altcharactersheet>
       <exportsheet>Export Character to Roll20</exportsheet>
+      <altexportsheet>Export Character to Roll20</altexportsheet>
+      <altexportsheet>Simple Text Export</altexportsheet>
       <altexportsheet>Export Character to Roll20</altexportsheet>
       <altexportsheet>Simple Text Export</altexportsheet>
       <altexportsheet>Export Character to Roll20</altexportsheet>
@@ -6036,7 +6038,7 @@
       </disadvantages>
       <quirks count="0" />
       <features count="0" />
-      <skills count="2">
+      <skills count="4">
         <trait type="Skills" idkey="187">
           <name>Innate Attack</name>
           <nameext>Projectile</nameext>
@@ -6068,6 +6070,76 @@
           <ref>
             <page>B201</page>
             <default>DX - 4, SK:Innate Attack - 2</default>
+          </ref>
+          <attackmodes count="1">
+            <attackmode>
+              <name />
+            </attackmode>
+          </attackmodes>
+        </trait>
+        <trait type="Skills" idkey="13365">
+          <name>Meditation</name>
+          <needscheck>-1</needscheck>
+          <taboofailed>0</taboofailed>
+          <cat>_General, Esoteric</cat>
+          <points>2</points>
+          <type>Will/H</type>
+          <step>-1</step>
+          <stepoff>Will</stepoff>
+          <level>12</level>
+          <calcs>
+            <sd>0</sd>
+            <deflevel>0</deflevel>
+            <pointmult>1</pointmult>
+            <levelmult>1</levelmult>
+            <syslevels>0</syslevels>
+            <extralevels>0</extralevels>
+            <baselevel>12</baselevel>
+            <basepoints>2</basepoints>
+            <multpoints>2</multpoints>
+            <apppoints>2</apppoints>
+            <premodspoints>2</premodspoints>
+            <baseapppoints>2</baseapppoints>
+          </calcs>
+          <armordata />
+          <ref>
+            <page>B207</page>
+            <default>Will - 6, SK:Autohypnosis - 4</default>
+          </ref>
+          <attackmodes count="1">
+            <attackmode>
+              <name />
+            </attackmode>
+          </attackmodes>
+        </trait>
+        <trait type="Skills" idkey="13366">
+          <name>Search</name>
+          <needscheck>-1</needscheck>
+          <taboofailed>0</taboofailed>
+          <cat>_General, Police, Spy</cat>
+          <points>2</points>
+          <type>Per/A</type>
+          <step>+0</step>
+          <stepoff>Per</stepoff>
+          <level>13</level>
+          <calcs>
+            <sd>0</sd>
+            <deflevel>0</deflevel>
+            <pointmult>1</pointmult>
+            <levelmult>1</levelmult>
+            <syslevels>0</syslevels>
+            <extralevels>0</extralevels>
+            <baselevel>13</baselevel>
+            <basepoints>2</basepoints>
+            <multpoints>2</multpoints>
+            <apppoints>2</apppoints>
+            <premodspoints>2</premodspoints>
+            <baseapppoints>2</baseapppoints>
+          </calcs>
+          <armordata />
+          <ref>
+            <page>B219</page>
+            <default>Per - 5, SK:Criminology - 5, SK:Detective!</default>
           </ref>
           <attackmodes count="1">
             <attackmode>
@@ -36996,7 +37068,7 @@
         <filename>mental_16.png</filename>
         <criteria>Advantages where cat listincludes {mental}</criteria>
         <image><![CDATA[iVBORw0KGgoAAAANSUhEUgAAAA8AAAAQCAYAAADJViUEAAAABGdBTUEAALGPC/xhBQAAAAlwSFlz
-AAALDwAACw8BkvkDpQAAAAd0SU1FB+EGERIZD2I0ZEoAAAD7SURBVDhPvZI/yoNAEMU9in8KC8FK
+AAALDgAACw4BQL7hQQAAAAd0SU1FB+EGERIZD2I0ZEoAAAD7SURBVDhPvZI/yoNAEMU9in8KC8FK
 bKwttLMRQbDwCFqJCHZWVvYexs4beJtJnmaWTXaT70sTHo8dduY3zA5rkEbLspDv+9S2Lc3zTEVR
 UJ7ntO87yXVSeClJEhqGgY7jUDyOI63rKho8jktRFIlC0zQV476ua9q27WwgQMhxnLcgbFnWmW+a
 5nsYRr4sSxXmZBAEWhBGvqoqFcZY/G7P8/4PY8tcIC8ONu5lOBlO0/QZdl1XwLJt2z4BngRxlmX6
@@ -37008,7 +37080,7 @@ xg3BO+JKFy8frAAAAABJRU5ErkJggg==]]></image>
         <filename>mental_16.png</filename>
         <criteria>Disadvantages where cat listincludes {mental}</criteria>
         <image><![CDATA[iVBORw0KGgoAAAANSUhEUgAAAA8AAAAQCAYAAADJViUEAAAABGdBTUEAALGPC/xhBQAAAAlwSFlz
-AAALDwAACw8BkvkDpQAAAAd0SU1FB+EGERIZD2I0ZEoAAAD7SURBVDhPvZI/yoNAEMU9in8KC8FK
+AAALDgAACw4BQL7hQQAAAAd0SU1FB+EGERIZD2I0ZEoAAAD7SURBVDhPvZI/yoNAEMU9in8KC8FK
 bKwttLMRQbDwCFqJCHZWVvYexs4beJtJnmaWTXaT70sTHo8dduY3zA5rkEbLspDv+9S2Lc3zTEVR
 UJ7ntO87yXVSeClJEhqGgY7jUDyOI63rKho8jktRFIlC0zQV476ua9q27WwgQMhxnLcgbFnWmW+a
 5nsYRr4sSxXmZBAEWhBGvqoqFcZY/G7P8/4PY8tcIC8ONu5lOBlO0/QZdl1XwLJt2z4BngRxlmX6
@@ -37066,8 +37138,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAA
-Cw8BkvkDpQAAA5NJREFUOE9lk3tM01cUx49AeUO1gFApA3mpW0JmshkTY+KGUZljsvgoGmXozHA+
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
+Cw4BQL7hQQAAA5NJREFUOE9lk3tM01cUx49AeUO1gFApA3mpW0JmshkTY+KGUZljsvgoGmXozHA+
 EPQvjYmIc8l0bjI25kSXKGYQH6gBFcUXY10qETtny6PwYy2dtmBJf0VaUqA5O+cuEN2anNz7uz3n
 c8/5nnvA5XKB3+8HSZJAp9OFt7W1xXg9niBEhJGXLxdsL9pmLj9YJo+Pj7/LZ+3t7YpLFy/G6PV6
 hdstA5+NjY0ByPK/H8anxpxl2dnjczMysOXBg6+cTieszvv4BQAg26GDZffdbjccPlReOTc9Ezeu
@@ -37136,8 +37208,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAA
-Cw8BkvkDpQAAA5NJREFUOE9lk3tM01cUx49AeUO1gFApA3mpW0JmshkTY+KGUZljsvgoGmXozHA+
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
+Cw4BQL7hQQAAA5NJREFUOE9lk3tM01cUx49AeUO1gFApA3mpW0JmshkTY+KGUZljsvgoGmXozHA+
 EPQvjYmIc8l0bjI25kSXKGYQH6gBFcUXY10qETtny6PwYy2dtmBJf0VaUqA5O+cuEN2anNz7uz3n
 c8/5nnvA5XKB3+8HSZJAp9OFt7W1xXg9niBEhJGXLxdsL9pmLj9YJo+Pj7/LZ+3t7YpLFy/G6PV6
 hdstA5+NjY0ByPK/H8anxpxl2dnjczMysOXBg6+cTieszvv4BQAg26GDZffdbjccPlReOTc9Ezeu
@@ -37206,8 +37278,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAA
-Cw8BkvkDpQAABTtJREFUOE9tVHlQk1cQ3xA5FPEElcOEU/A+8WprFcQCCgI61AOtovWgtv7RqZwT
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
+Cw4BQL7hQQAABTtJREFUOE9tVHlQk1cQ3xA5FPEElcOEU/A+8WprFcQCCgI61AOtovWgtv7RqZwT
 22o5PYvBKkJCiiYIIYQjciRMEKiOQggKigYB0TC2NlyKUa7Xfd+Mzjj2m3nzvWPf77e7v30L7W1t
 PPG1a2lV6iq3pvtNUCSXQ19vLyTGJ0ClSgVPWlth146dIBJmASEEGhoaQJgpgK6uLhgZGYYfjhyB
 iEOHQKVUMef1dfXQ0dEBXXq929Xs7DhRVtZRyLuee9uZwyGeS5aSqJ+OKaS5ucHDQ0Nmp5JToKWl
@@ -37284,8 +37356,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAA
-Cw8BkvkDpQAABTtJREFUOE9tVHlQk1cQ3xA5FPEElcOEU/A+8WprFcQCCgI61AOtovWgtv7RqZwT
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
+Cw4BQL7hQQAABTtJREFUOE9tVHlQk1cQ3xA5FPEElcOEU/A+8WprFcQCCgI61AOtovWgtv7RqZwT
 22o5PYvBKkJCiiYIIYQjciRMEKiOQggKigYB0TC2NlyKUa7Xfd+Mzjj2m3nzvWPf77e7v30L7W1t
 PPG1a2lV6iq3pvtNUCSXQ19vLyTGJ0ClSgVPWlth146dIBJmASEEGhoaQJgpgK6uLhgZGYYfjhyB
 iEOHQKVUMef1dfXQ0dEBXXq929Xs7DhRVtZRyLuee9uZwyGeS5aSqJ+OKaS5ucHDQ0Nmp5JToKWl
@@ -37362,8 +37434,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAA
-Cw8BkvkDpQAAAkFJREFUKFNj+Pr1K8P79+8Znj59ynDr1i31msqqiQmxcQdbm1tWrVm92vjZs2cM
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
+Cw4BQL7hQQAAAkFJREFUKFNj+Pr1K8P79+8Znj59ynDr1i31msqqiQmxcQdbm1tWrVm92vjZs2cM
 ////Z/j79y8Dw8+fP8Gcc2fPers5u/znZuf8z8vB+Z+ThfW/lpr6/9OnTlWB5P/8+cMANvnz58/m
 zg6O/xkYGP4rysj+V1VU+q8kJw/mgzQ8e/o0AKQBbGpdbe0mkISyvAIKBmkCiefn5F4EK3744IGd
 raXVfw5mlv8qCoooikF8QV6+/xoqqv+PHjniz7Bq5apiIT7+/3KSUigKYRjkHJAGoMc7GPp6e1Yw
@@ -37426,8 +37498,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAA
-Cw8BkvkDpQAAAkFJREFUKFNj+Pr1K8P79+8Znj59ynDr1i31msqqiQmxcQdbm1tWrVm92vjZs2cM
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
+Cw4BQL7hQQAAAkFJREFUKFNj+Pr1K8P79+8Znj59ynDr1i31msqqiQmxcQdbm1tWrVm92vjZs2cM
 ////Z/j79y8Dw8+fP8Gcc2fPers5u/znZuf8z8vB+Z+ThfW/lpr6/9OnTlWB5P/8+cMANvnz58/m
 zg6O/xkYGP4rysj+V1VU+q8kJw/mgzQ8e/o0AKQBbGpdbe0mkISyvAIKBmkCiefn5F4EK3744IGd
 raXVfw5mlv8qCoooikF8QV6+/xoqqv+PHjniz7Bq5apiIT7+/3KSUigKYRjkHJAGoMc7GPp6e1Yw
@@ -37490,8 +37562,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAA
-Cw8BkvkDpQAAAnhJREFUOE9VUklMk1EQHgiNIjsGEZEipZa4REiUoB6ApERD4sEFg0i8GKnVeAOR
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
+Cw4BQL7hQQAAAnhJREFUOE9VUklMk1EQHgiNIjsGEZEipZa4REiUoB6ApERD4sEFg0i8GKnVeAOR
 eFT04BKMtRgTPVUSXAktxBM1pUEoWKtiWaXYlcVg96bLD+ObX0U4fJl/3vu+eTPz/RCNRtchFosB
 IhIEGrX6jrq7uzzKzj6OjMDo11GASCSyChKEQiF4r9XCh4EBwRFpFYpFIjSbzY1erxfGx8YBVlZW
 VvG3MgwNDsLLzk5J2YFSPwBgXs42fPRQ0flraUm4SloDMUWdTnc8P3c7T85ISUUS3m5tnYfJiQmw
@@ -37555,8 +37627,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAA
-Cw8BkvkDpQAAAnhJREFUOE9VUklMk1EQHgiNIjsGEZEipZa4REiUoB6ApERD4sEFg0i8GKnVeAOR
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
+Cw4BQL7hQQAAAnhJREFUOE9VUklMk1EQHgiNIjsGEZEipZa4REiUoB6ApERD4sEFg0i8GKnVeAOR
 eFT04BKMtRgTPVUSXAktxBM1pUEoWKtiWaXYlcVg96bLD+ObX0U4fJl/3vu+eTPz/RCNRtchFosB
 IhIEGrX6jrq7uzzKzj6OjMDo11GASCSyChKEQiF4r9XCh4EBwRFpFYpFIjSbzY1erxfGx8YBVlZW
 VvG3MgwNDsLLzk5J2YFSPwBgXs42fPRQ0flraUm4SloDMUWdTnc8P3c7T85ISUUS3m5tnYfJiQmw

--- a/Documents/Artillery Mage (NPC).gca5
+++ b/Documents/Artillery Mage (NPC).gca5
@@ -5,7 +5,7 @@
       <name>GURPS Character Assistant</name>
       <version>GCA5Engine, Version=5.0.202.0</version>
       <copyright>Program code is copyright © 1995-2022 by Armin D. Sykes. All data files, graphics, and other GURPS-specific content is copyright © 2005 and other years by Steve Jackson Games Incorporated. GURPS and the all-seeing pyramid are registered trademarks of Steve Jackson Games Incorporated. All rights reserved.</copyright>
-      <datecreated>Saturday, November 12, 2022</datecreated>
+      <datecreated>Friday, December 30, 2022</datecreated>
     </author>
     <system>
       <version>5</version>
@@ -189,14 +189,16 @@
       <altexportsheet>Simple Text Export</altexportsheet>
       <altexportsheet>Export Character to Roll20</altexportsheet>
       <altexportsheet>Simple Text Export</altexportsheet>
+      <altexportsheet>Export Character to Roll20</altexportsheet>
+      <altexportsheet>Simple Text Export</altexportsheet>
       <altexportsheet>Simple Text Export</altexportsheet>
     </output>
     <vitals>
       <race>Human</race>
-      <height />
-      <weight />
-      <age />
-      <appearance />
+      <height>5'9"</height>
+      <weight>154</weight>
+      <age>27</age>
+      <appearance>Typical, smug wizard.</appearance>
       <portraitfile />
     </vitals>
     <basicdefense>
@@ -37068,7 +37070,7 @@
         <filename>mental_16.png</filename>
         <criteria>Advantages where cat listincludes {mental}</criteria>
         <image><![CDATA[iVBORw0KGgoAAAANSUhEUgAAAA8AAAAQCAYAAADJViUEAAAABGdBTUEAALGPC/xhBQAAAAlwSFlz
-AAALDgAACw4BQL7hQQAAAAd0SU1FB+EGERIZD2I0ZEoAAAD7SURBVDhPvZI/yoNAEMU9in8KC8FK
+AAALDQAACw0B7QfALAAAAAd0SU1FB+EGERIZD2I0ZEoAAAD7SURBVDhPvZI/yoNAEMU9in8KC8FK
 bKwttLMRQbDwCFqJCHZWVvYexs4beJtJnmaWTXaT70sTHo8dduY3zA5rkEbLspDv+9S2Lc3zTEVR
 UJ7ntO87yXVSeClJEhqGgY7jUDyOI63rKho8jktRFIlC0zQV476ua9q27WwgQMhxnLcgbFnWmW+a
 5nsYRr4sSxXmZBAEWhBGvqoqFcZY/G7P8/4PY8tcIC8ONu5lOBlO0/QZdl1XwLJt2z4BngRxlmX6
@@ -37080,7 +37082,7 @@ xg3BO+JKFy8frAAAAABJRU5ErkJggg==]]></image>
         <filename>mental_16.png</filename>
         <criteria>Disadvantages where cat listincludes {mental}</criteria>
         <image><![CDATA[iVBORw0KGgoAAAANSUhEUgAAAA8AAAAQCAYAAADJViUEAAAABGdBTUEAALGPC/xhBQAAAAlwSFlz
-AAALDgAACw4BQL7hQQAAAAd0SU1FB+EGERIZD2I0ZEoAAAD7SURBVDhPvZI/yoNAEMU9in8KC8FK
+AAALDQAACw0B7QfALAAAAAd0SU1FB+EGERIZD2I0ZEoAAAD7SURBVDhPvZI/yoNAEMU9in8KC8FK
 bKwttLMRQbDwCFqJCHZWVvYexs4beJtJnmaWTXaT70sTHo8dduY3zA5rkEbLspDv+9S2Lc3zTEVR
 UJ7ntO87yXVSeClJEhqGgY7jUDyOI63rKho8jktRFIlC0zQV476ua9q27WwgQMhxnLcgbFnWmW+a
 5nsYRr4sSxXmZBAEWhBGvqoqFcZY/G7P8/4PY8tcIC8ONu5lOBlO0/QZdl1XwLJt2z4BngRxlmX6
@@ -37138,8 +37140,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
-Cw4BQL7hQQAAA5NJREFUOE9lk3tM01cUx49AeUO1gFApA3mpW0JmshkTY+KGUZljsvgoGmXozHA+
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDQAA
+Cw0B7QfALAAAA5NJREFUOE9lk3tM01cUx49AeUO1gFApA3mpW0JmshkTY+KGUZljsvgoGmXozHA+
 EPQvjYmIc8l0bjI25kSXKGYQH6gBFcUXY10qETtny6PwYy2dtmBJf0VaUqA5O+cuEN2anNz7uz3n
 c8/5nnvA5XKB3+8HSZJAp9OFt7W1xXg9niBEhJGXLxdsL9pmLj9YJo+Pj7/LZ+3t7YpLFy/G6PV6
 hdstA5+NjY0ByPK/H8anxpxl2dnjczMysOXBg6+cTieszvv4BQAg26GDZffdbjccPlReOTc9Ezeu
@@ -37208,8 +37210,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
-Cw4BQL7hQQAAA5NJREFUOE9lk3tM01cUx49AeUO1gFApA3mpW0JmshkTY+KGUZljsvgoGmXozHA+
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDQAA
+Cw0B7QfALAAAA5NJREFUOE9lk3tM01cUx49AeUO1gFApA3mpW0JmshkTY+KGUZljsvgoGmXozHA+
 EPQvjYmIc8l0bjI25kSXKGYQH6gBFcUXY10qETtny6PwYy2dtmBJf0VaUqA5O+cuEN2anNz7uz3n
 c8/5nnvA5XKB3+8HSZJAp9OFt7W1xXg9niBEhJGXLxdsL9pmLj9YJo+Pj7/LZ+3t7YpLFy/G6PV6
 hdstA5+NjY0ByPK/H8anxpxl2dnjczMysOXBg6+cTieszvv4BQAg26GDZffdbjccPlReOTc9Ezeu
@@ -37278,8 +37280,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
-Cw4BQL7hQQAABTtJREFUOE9tVHlQk1cQ3xA5FPEElcOEU/A+8WprFcQCCgI61AOtovWgtv7RqZwT
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDQAA
+Cw0B7QfALAAABTtJREFUOE9tVHlQk1cQ3xA5FPEElcOEU/A+8WprFcQCCgI61AOtovWgtv7RqZwT
 22o5PYvBKkJCiiYIIYQjciRMEKiOQggKigYB0TC2NlyKUa7Xfd+Mzjj2m3nzvWPf77e7v30L7W1t
 PPG1a2lV6iq3pvtNUCSXQ19vLyTGJ0ClSgVPWlth146dIBJmASEEGhoaQJgpgK6uLhgZGYYfjhyB
 iEOHQKVUMef1dfXQ0dEBXXq929Xs7DhRVtZRyLuee9uZwyGeS5aSqJ+OKaS5ucHDQ0Nmp5JToKWl
@@ -37356,8 +37358,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
-Cw4BQL7hQQAABTtJREFUOE9tVHlQk1cQ3xA5FPEElcOEU/A+8WprFcQCCgI61AOtovWgtv7RqZwT
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDQAA
+Cw0B7QfALAAABTtJREFUOE9tVHlQk1cQ3xA5FPEElcOEU/A+8WprFcQCCgI61AOtovWgtv7RqZwT
 22o5PYvBKkJCiiYIIYQjciRMEKiOQggKigYB0TC2NlyKUa7Xfd+Mzjj2m3nzvWPf77e7v30L7W1t
 PPG1a2lV6iq3pvtNUCSXQ19vLyTGJ0ClSgVPWlth146dIBJmASEEGhoaQJgpgK6uLhgZGYYfjhyB
 iEOHQKVUMef1dfXQ0dEBXXq929Xs7DhRVtZRyLuee9uZwyGeS5aSqJ+OKaS5ucHDQ0Nmp5JToKWl
@@ -37434,8 +37436,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
-Cw4BQL7hQQAAAkFJREFUKFNj+Pr1K8P79+8Znj59ynDr1i31msqqiQmxcQdbm1tWrVm92vjZs2cM
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDQAA
+Cw0B7QfALAAAAkFJREFUKFNj+Pr1K8P79+8Znj59ynDr1i31msqqiQmxcQdbm1tWrVm92vjZs2cM
 ////Z/j79y8Dw8+fP8Gcc2fPers5u/znZuf8z8vB+Z+ThfW/lpr6/9OnTlWB5P/8+cMANvnz58/m
 zg6O/xkYGP4rysj+V1VU+q8kJw/mgzQ8e/o0AKQBbGpdbe0mkISyvAIKBmkCiefn5F4EK3744IGd
 raXVfw5mlv8qCoooikF8QV6+/xoqqv+PHjniz7Bq5apiIT7+/3KSUigKYRjkHJAGoMc7GPp6e1Yw
@@ -37498,8 +37500,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
-Cw4BQL7hQQAAAkFJREFUKFNj+Pr1K8P79+8Znj59ynDr1i31msqqiQmxcQdbm1tWrVm92vjZs2cM
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDQAA
+Cw0B7QfALAAAAkFJREFUKFNj+Pr1K8P79+8Znj59ynDr1i31msqqiQmxcQdbm1tWrVm92vjZs2cM
 ////Z/j79y8Dw8+fP8Gcc2fPers5u/znZuf8z8vB+Z+ThfW/lpr6/9OnTlWB5P/8+cMANvnz58/m
 zg6O/xkYGP4rysj+V1VU+q8kJw/mgzQ8e/o0AKQBbGpdbe0mkISyvAIKBmkCiefn5F4EK3744IGd
 raXVfw5mlv8qCoooikF8QV6+/xoqqv+PHjniz7Bq5apiIT7+/3KSUigKYRjkHJAGoMc7GPp6e1Yw
@@ -37562,8 +37564,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
-Cw4BQL7hQQAAAnhJREFUOE9VUklMk1EQHgiNIjsGEZEipZa4REiUoB6ApERD4sEFg0i8GKnVeAOR
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDQAA
+Cw0B7QfALAAAAnhJREFUOE9VUklMk1EQHgiNIjsGEZEipZa4REiUoB6ApERD4sEFg0i8GKnVeAOR
 eFT04BKMtRgTPVUSXAktxBM1pUEoWKtiWaXYlcVg96bLD+ObX0U4fJl/3vu+eTPz/RCNRtchFosB
 IhIEGrX6jrq7uzzKzj6OjMDo11GASCSyChKEQiF4r9XCh4EBwRFpFYpFIjSbzY1erxfGx8YBVlZW
 VvG3MgwNDsLLzk5J2YFSPwBgXs42fPRQ0flraUm4SloDMUWdTnc8P3c7T85ISUUS3m5tnYfJiQmw
@@ -37627,8 +37629,8 @@ z86dSz83cz7h/HhPTM/9CxEXbvUG9g5c9Ll4+ZL7pQt9Tn1nL9tdPnXF5srJq4yrndcsr3X0W/S3
 /2TxU/uA5UDHdavrXTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriX
 eW/h/sYH6AdFD6UeVjxSfNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2d
 mnafvvF05dOJZ+nPFmYKf5X+tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/M
-F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDgAA
-Cw4BQL7hQQAAAnhJREFUOE9VUklMk1EQHgiNIjsGEZEipZa4REiUoB6ApERD4sEFg0i8GKnVeAOR
+F72Rf3P4LeNt37vwd5MLWe+x7ys/6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDQAA
+Cw0B7QfALAAAAnhJREFUOE9VUklMk1EQHgiNIjsGEZEipZa4REiUoB6ApERD4sEFg0i8GKnVeAOR
 eFT04BKMtRgTPVUSXAktxBM1pUEoWKtiWaXYlcVg96bLD+ObX0U4fJl/3vu+eTPz/RCNRtchFosB
 IhIEGrX6jrq7uzzKzj6OjMDo11GASCSyChKEQiF4r9XCh4EBwRFpFYpFIjSbzY1erxfGx8YBVlZW
 VvG3MgwNDsLLzk5J2YFSPwBgXs42fPRQ0flraUm4SloDMUWdTnc8P3c7T85ISUUS3m5tnYfJiQmw

--- a/Documents/roll20.schema.json
+++ b/Documents/roll20.schema.json
@@ -1,809 +1,862 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "http://wanderingmonsters.com/gurps-roll20.json",
+  "$id": "http://example.com/example.json",
   "type": "object",
   "default": {},
   "title": "Root Schema",
   "required": [
-    "character_name",
-    "fullname",
-    "playername",
-    "nickname",
-    "race",
-    "race_ref",
-    "template_names",
-    "gender",
-    "size",
-    "apply_size_modifier",
-    "reactions",
-    "campaign_tl",
-    "tl",
-    "tl_pts",
-    "status",
-    "wealth",
-    "income",
-    "cost_of_living",
-    "stash",
-    "age",
-    "height",
-    "weight",
-    "appearance",
-    "general_appearance",
-    "strength_mod",
-    "strength_points",
-    "dexterity_mod",
-    "dexterity_points",
-    "intelligence_mod",
-    "health_mod",
-    "health_points",
-    "perception_mod",
-    "perception_points",
-    "vision_mod",
-    "hearing_mod",
-    "hearing_points",
-    "taste_smell_mod",
-    "taste_smell_points",
-    "touch_mod",
-    "willpower_mod",
-    "willpower_points",
-    "fear_check_mod",
-    "fear_check_points",
-    "stun_check_mod",
-    "knockdown_check_mod",
-    "unconscious_check_mod",
-    "unconscious_check_points",
-    "death_check_mod",
-    "death_check_points",
-    "basic_speed_mod",
-    "basic_speed_points",
-    "basic_move_mod",
-    "basic_move_points",
-    "enhanced_ground_move_mod",
-    "enhanced_ground_move_points",
-    "dodge_mod",
-    "lift_st_mod",
-    "lift_st_points",
-    "striking_st_mod",
-    "striking_st_points",
-    "hit_points_mod",
-    "hit_points_points",
-    "hit_points",
-    "fatigue_points_mod",
-    "fatigue_points_points",
-    "fatigue_points",
-    "flight_checked",
-    "flight_points",
-    "basic_air_move_mod",
-    "basic_air_move_points",
-    "enhanced_air_level",
-    "enhanced_air_move_points",
-    "amphibious_checked",
-    "amphibious_points",
-    "basic_water_move_mod",
-    "basic_water_move_points",
-    "enhanced_water_level",
-    "enhanced_water_move_points",
-    "super_jump_entered_level",
-    "super_jump_points",
-    "spell_bonus",
-    "repeating_languages",
-    "repeating_cultures",
-    "repeating_traits",
-    "repeating_perks",
-    "repeating_quirks",
-    "repeating_disadvantages",
-    "repeating_racial",
-    "repeating_skills",
-    "repeating_techniquesrevised",
-    "repeating_defense",
-    "repeating_melee",
-    "repeating_ranged",
-    "repeating_item",
-    "repeating_spells",
-    "final_values"
+    "CharacterName",
+    "Fullname",
+    "Playername",
+    "Nickname",
+    "Race",
+    "RaceRef",
+    "TemplateNames",
+    "Gender",
+    "Size",
+    "ApplySizeModifier",
+    "Reactions",
+    "CampaignTl",
+    "TotalPoints",
+    "Tl",
+    "TlPts",
+    "Status",
+    "Wealth",
+    "Income",
+    "CostOfLiving",
+    "Stash",
+    "Age",
+    "Height",
+    "Weight",
+    "Appearance",
+    "GeneralAppearance",
+    "StrengthMod",
+    "StrengthPoints",
+    "DexterityMod",
+    "DexterityPoints",
+    "IntelligenceMod",
+    "IntelligencePoints",
+    "HealthMod",
+    "HealthPoints",
+    "PerceptionMod",
+    "PerceptionPoints",
+    "VisionMod",
+    "VisionPoints",
+    "HearingMod",
+    "HearingPoints",
+    "TasteSmellMod",
+    "TasteSmellPoints",
+    "TouchMod",
+    "TouchPoints",
+    "WillpowerMod",
+    "WillpowerPoints",
+    "FearCheckMod",
+    "FearCheckPoints",
+    "StunCheckMod",
+    "KnockdownCheckMod",
+    "UnconsciousCheckMod",
+    "UnconsciousCheckPoints",
+    "DeathCheckMod",
+    "DeathCheckPoints",
+    "BasicSpeedMod",
+    "BasicSpeedPoints",
+    "BasicMoveMod",
+    "BasicMovePoints",
+    "EnhancedGroundMoveMod",
+    "EnhancedGroundMovePoints",
+    "DodgeMod",
+    "LiftStMod",
+    "LiftStPoints",
+    "StrikingStMod",
+    "StrikingStPoints",
+    "HitPointsMod",
+    "HitPointsPoints",
+    "HitPoints",
+    "FatiguePointsMod",
+    "FatiguePointsPoints",
+    "FatiguePoints",
+    "FlightChecked",
+    "FlightPoints",
+    "BasicAirMoveMod",
+    "BasicAirMovePoints",
+    "EnhancedAirLevel",
+    "EnhancedAirMovePoints",
+    "AmphibiousChecked",
+    "AmphibiousPoints",
+    "BasicWaterMoveMod",
+    "BasicWaterMovePoints",
+    "EnhancedWaterLevel",
+    "EnhancedWaterMovePoints",
+    "SuperJumpEnteredLevel",
+    "SuperJumpPoints",
+    "SpellBonus",
+    "CombatReflexes",
+    "RepeatingLanguages",
+    "RepeatingCultures",
+    "RepeatingTraits",
+    "RepeatingPerks",
+    "RepeatingQuirks",
+    "RepeatingDisadvantages",
+    "RepeatingRacial",
+    "RepeatingSkills",
+    "RepeatingTechniquesrevised",
+    "RepeatingDefense",
+    "RepeatingMelee",
+    "RepeatingRanged",
+    "RepeatingItem",
+    "RepeatingSpells"
   ],
   "properties": {
-    "character_name": {
+    "CharacterName": {
       "type": "string",
       "default": "",
-      "title": "The character_name Schema",
+      "title": "The Character Name.",
       "examples": [
-        "Bartholomew Mactavish"
+        "Rampage"
       ]
     },
-    "fullname": {
+    "Fullname": {
       "type": "string",
       "default": "",
-      "title": "The fullname Schema",
+      "title": "The Fullname.",
       "examples": [
-        "Bartholomew Mactavish"
+        "Rampage (NPC)"
       ]
     },
-    "playername": {
+    "Playername": {
       "type": "string",
       "default": "",
-      "title": "The playername Schema",
+      "title": "The Playername.",
       "examples": [
         "NPC"
       ]
     },
-    "nickname": {
+    "Nickname": {
       "type": "string",
       "default": "",
-      "title": "The nickname Schema",
+      "title": "The Nickname.",
       "examples": [
-        "Bart"
+        "Rampage"
       ]
     },
-    "race": {
+    "Race": {
       "type": "string",
       "default": "",
-      "title": "The race Schema",
+      "title": "The character's Race.",
       "examples": [
         "Human"
       ]
     },
-    "race_ref": {
+    "RaceRef": {
       "type": "string",
       "default": "",
-      "title": "The race_ref Schema",
+      "title": "The Race Page Ref.",
       "examples": [
-        ""
+        "B21"
       ]
     },
-    "template_names": {
+    "TemplateNames": {
       "type": "string",
       "default": "",
-      "title": "The template_names Schema",
+      "title": "The Template Names.",
       "examples": [
-        "Hill People"
+        "Human Thief"
       ]
     },
-    "gender": {
+    "Gender": {
       "type": "string",
       "default": "",
-      "title": "The gender Schema",
+      "title": "The Gender.",
       "examples": [
         "Male"
       ]
     },
-    "size": {
-      "type": "integer",
-      "default": 0,
-      "title": "The size Schema",
+    "Size": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Character's Size Modifier",
       "examples": [
-        0
+        0.0
       ]
     },
-    "apply_size_modifier": {
+    "ApplySizeModifier": {
       "type": "boolean",
       "default": false,
-      "title": "The apply_size_modifier Schema",
+      "title": "The ApplySizeModifier to character sheet",
       "examples": [
         false
       ]
     },
-    "reactions": {
+    "Reactions": {
       "type": "string",
       "default": "",
-      "title": "The reactions Schema",
+      "title": "The Reactions Description Box.",
       "examples": [
-        ""
+        "+2 from 'Charisma 2'\nConditional:\n-2 from 'Reputation 2 (Gang Leader; 7 or less, +1, *1/3; Large class, +1, *1/2)'"
       ]
     },
-    "campaign_tl": {
-      "type": "integer",
-      "default": 0,
-      "title": "The campaign_tl Schema",
+    "CampaignTl": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Campaign Tl.",
       "examples": [
-        9
+        8.0
       ]
     },
-    "tl": {
-      "type": "integer",
-      "default": 0,
-      "title": "The tl Schema",
+    "TotalPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Total Points of Character.",
       "examples": [
-        9
+        150.0
       ]
     },
-    "tl_pts": {
-      "type": "integer",
-      "default": 0,
-      "title": "The tl_pts Schema",
+    "Tl": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Character's Tl.",
       "examples": [
-        0
+        8.0
       ]
     },
-    "status": {
+    "TlPts": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Points spent on TL.",
+      "examples": [
+        0.0
+      ]
+    },
+    "Status": {
       "type": "string",
       "default": "",
-      "title": "The status Schema",
+      "title": "The Character's Status.",
       "examples": [
         "0"
       ]
     },
-    "wealth": {
+    "Wealth": {
       "type": "string",
       "default": "",
-      "title": "The wealth Schema",
+      "title": "The Wealth Level.",
       "examples": [
-        "Average"
+        "Comfortable"
       ]
     },
-    "income": {
-      "type": "integer",
-      "default": 0,
-      "title": "The income Schema",
+    "Income": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The character's monthly income.",
       "examples": [
-        700
+        5200.0
       ]
     },
-    "cost_of_living": {
-      "type": "integer",
-      "default": 0,
-      "title": "The cost_of_living Schema",
+    "CostOfLiving": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The character's Cost Of Living.",
       "examples": [
-        600
+        600.0
       ]
     },
-    "stash": {
-      "type": "integer",
-      "default": 0,
-      "title": "The stash Schema",
+    "Stash": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The character's avaiable cash.",
       "examples": [
-        100
+        5169.6
       ]
     },
-    "age": {
-      "type": "integer",
-      "default": 0,
-      "title": "The age Schema",
-      "examples": [
-        33
-      ]
-    },
-    "height": {
+    "Age": {
       "type": "string",
       "default": "",
-      "title": "The height Schema",
+      "title": "The character's Age.",
       "examples": [
-        "5' 7\""
+        "27"
       ]
     },
-    "weight": {
-      "type": "integer",
-      "default": 0,
-      "title": "The weight Schema",
-      "examples": [
-        180
-      ]
-    },
-    "appearance": {
-      "type": "integer",
-      "default": 0,
-      "title": "The appearance Schema",
-      "examples": [
-        4
-      ]
-    },
-    "general_appearance": {
+    "Height": {
       "type": "string",
       "default": "",
-      "title": "The general_appearance Schema",
+      "title": "The character's Height.",
       "examples": [
-        "scruffy, nerf herder."
+        "6'"
       ]
     },
-    "strength_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The strength_mod Schema",
+    "Weight": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The character's Weight.",
       "examples": [
-        0
+        210.0
       ]
     },
-    "strength_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The strength_points Schema",
+    "Appearance": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The character points spent on appearance.",
       "examples": [
-        10
+        -24,
+        -20,
+        -16,
+        -8,
+        -4,
+        0,
+        4,
+        12,
+        16,
+        20
       ]
     },
-    "dexterity_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The dexterity_mod Schema",
+    "GeneralAppearance": {
+      "type": "string",
+      "default": "",
+      "title": "The character's General Appearance.",
       "examples": [
-        0
+        "Short mohawk, painted face, likes to wear chains, like something out of Road Warrior."
       ]
     },
-    "dexterity_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The dexterity_points Schema",
+    "StrengthMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Strength Modifier.",
       "examples": [
-        40
+        1.0
       ]
     },
-    "intelligence_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The intelligence_mod Schema",
+    "StrengthPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Strength Character Points.",
       "examples": [
-        40
+        60.0
       ]
     },
-    "health_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The health_mod Schema",
+    "DexterityMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Dexterity Modifier.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "health_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The health_points Schema",
+    "DexterityPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Dexterity Character Points.",
       "examples": [
-        10
+        40.0
       ]
     },
-    "perception_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The perception_mod Schema",
+    "IntelligenceMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Intelligence Modifier.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "perception_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The perception_points Schema",
+    "IntelligencePoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Intelligence Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "vision_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The vision_mod Schema",
+    "HealthMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Health Modifier.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "hearing_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The hearing_mod Schema",
+    "HealthPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Health Character Points.",
       "examples": [
-        0
+        20.0
       ]
     },
-    "hearing_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The hearing_points Schema",
+    "PerceptionMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Perception Modifier.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "taste_smell_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The taste_smell_mod Schema",
+    "PerceptionPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Perception Character Points.",
       "examples": [
-        0
+        10.0
       ]
     },
-    "taste_smell_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The taste_smell_points Schema",
+    "VisionMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Vision Modifier.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "touch_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The touch_mod Schema",
+    "VisionPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The VisionCharacter Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "willpower_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The willpower_mod Schema",
+    "HearingMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Hearing Modifier.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "willpower_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The willpower_points Schema",
+    "HearingPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Hearing Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "fear_check_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The fear_check_mod Schema",
+    "TasteSmellMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Taste Smell Modifier.",
       "examples": [
-        2
+        0.0
       ]
     },
-    "fear_check_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The fear_check_points Schema",
+    "TasteSmellPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Taste Smell Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "stun_check_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The stun_check_mod Schema",
+    "TouchMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Touch Modifier.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "knockdown_check_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The knockdown_check_mod Schema",
+    "TouchPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Touch Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "unconscious_check_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The unconscious_check_mod Schema",
+    "WillpowerMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Willpower Modifier.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "unconscious_check_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The unconscious_check_points Schema",
+    "WillpowerPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Willpower Character Points.",
       "examples": [
-        0
+        10.0
       ]
     },
-    "death_check_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The death_check_mod Schema",
+    "FearCheckMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Fear Check Modifier.",
       "examples": [
-        0
+        2.0
       ]
     },
-    "death_check_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The death_check_points Schema",
+    "FearCheckPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Fear Check Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "basic_speed_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The basic_speed_mod Schema",
+    "StunCheckMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Stun Check Modifier.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "basic_speed_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The basic_speed_points Schema",
+    "KnockdownCheckMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Knockdown Check Modifier.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "basic_move_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The basic_move_mod Schema",
+    "UnconsciousCheckMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Unconscious Check Modifier.",
       "examples": [
-        0
+        1.0
       ]
     },
-    "basic_move_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The basic_move_points Schema",
+    "UnconsciousCheckPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Unconscious Check Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "enhanced_ground_move_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The enhanced_ground_move_mod Schema",
+    "DeathCheckMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Death Check Modifier.",
       "examples": [
-        0
+        1.0
       ]
     },
-    "enhanced_ground_move_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The enhanced_ground_move_points Schema",
+    "DeathCheckPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Death Check Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "dodge_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The dodge_mod Schema",
+    "BasicSpeedMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Basic Speed Modifier.",
       "examples": [
-        1
+        0.0
       ]
     },
-    "lift_st_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The lift_st_mod Schema",
+    "BasicSpeedPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Basic Speed Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "lift_st_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The lift_st_points Schema",
+    "BasicMoveMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Basic Move Modifier.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "striking_st_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The striking_st_mod Schema",
+    "BasicMovePoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Basic Move Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "striking_st_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The striking_st_points Schema",
+    "EnhancedGroundMoveMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Enhanced Ground Move Modifier.",
       "examples": [
-        0
+        0.5
       ]
     },
-    "hit_points_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The hit_points_mod Schema",
+    "EnhancedGroundMovePoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Enhanced Ground Move Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "hit_points_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The hit_points_points Schema",
+    "DodgeMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Dodge Modifier.",
       "examples": [
-        0
+        2.0
       ]
     },
-    "hit_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The hit_points Schema",
+    "LiftStMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Lift Strength Modifier.",
       "examples": [
-        11
+        7.0
       ]
     },
-    "fatigue_points_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The fatigue_points_mod Schema",
+    "LiftStPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Lift Strength Character Points.",
       "examples": [
-        0
+        15.0
       ]
     },
-    "fatigue_points_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The fatigue_points_points Schema",
+    "StrikingStMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Striking Strength Modifier.",
       "examples": [
-        0
+        4.0
       ]
     },
-    "fatigue_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The fatigue_points Schema",
+    "StrikingStPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Striking Strength Character Points.",
       "examples": [
-        11
+        0.0
       ]
     },
-    "flight_checked": {
+    "HitPointsMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Hit Points Modifier.",
+      "examples": [
+        0.0
+      ]
+    },
+    "HitPointsPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Hit Points Character Points.",
+      "examples": [
+        8.0
+      ]
+    },
+    "HitPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The character's Hit Points.",
+      "examples": [
+        21.0
+      ]
+    },
+    "FatiguePointsMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Fatigue Points Modifier.",
+      "examples": [
+        0.0
+      ]
+    },
+    "FatiguePointsPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Fatigue Points Character Points.",
+      "examples": [
+        0.0
+      ]
+    },
+    "FatiguePoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Fatigue Character Points.",
+      "examples": [
+        12.0
+      ]
+    },
+    "FlightChecked": {
       "type": "boolean",
       "default": false,
-      "title": "The flight_checked Schema",
+      "title": "Does the character have the Flight advantage.",
       "examples": [
         false
       ]
     },
-    "flight_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The flight_points Schema",
+    "FlightPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The character points spent on Flight.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "basic_air_move_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The basic_air_move_mod Schema",
+    "BasicAirMoveMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Basic Air Move Modifier.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "basic_air_move_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The basic_air_move_points Schema",
+    "BasicAirMovePoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Basic Air Move Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "enhanced_air_level": {
-      "type": "integer",
-      "default": 0,
-      "title": "The enhanced_air_level Schema",
+    "EnhancedAirLevel": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Enhanced Air Level.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "enhanced_air_move_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The enhanced_air_move_points Schema",
+    "EnhancedAirMovePoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Enhanced Air Move Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "amphibious_checked": {
+    "AmphibiousChecked": {
       "type": "boolean",
       "default": false,
-      "title": "The amphibious_checked Schema",
+      "title": "Is the character Amphibious?",
       "examples": [
         false
       ]
     },
-    "amphibious_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The amphibious_points Schema",
+    "AmphibiousPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Amphibious Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "basic_water_move_mod": {
-      "type": "integer",
-      "default": 0,
-      "title": "The basic_water_move_mod Schema",
+    "BasicWaterMoveMod": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Basic Water Move Modifier.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "basic_water_move_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The basic_water_move_points Schema",
+    "BasicWaterMovePoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Basic Water Move Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "enhanced_water_level": {
-      "type": "integer",
-      "default": 0,
-      "title": "The enhanced_water_level Schema",
+    "EnhancedWaterLevel": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Enhanced Water Level.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "enhanced_water_move_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The enhanced_water_move_points Schema",
+    "EnhancedWaterMovePoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Enhanced Water Move Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "super_jump_entered_level": {
-      "type": "integer",
-      "default": 0,
-      "title": "The super_jump_entered_level Schema",
+    "SuperJumpEnteredLevel": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Super Jump Level.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "super_jump_points": {
-      "type": "integer",
-      "default": 0,
-      "title": "The super_jump_points Schema",
+    "SuperJumpPoints": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Super Jump Character Points.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "spell_bonus": {
-      "type": "integer",
-      "default": 0,
-      "title": "The spell_bonus Schema",
+    "SpellBonus": {
+      "type": "number",
+      "default": 0.0,
+      "title": "The Spell Bonus. Typically pick the highest of Magery, Power Investiture.",
       "examples": [
-        0
+        0.0
       ]
     },
-    "repeating_languages": {
+    "CombatReflexes": {
+      "type": "boolean",
+      "default": false,
+      "title": "Does the character have Combat Reflexes?",
+      "examples": [
+        true
+      ]
+    },
+    "RepeatingLanguages": {
       "type": "array",
       "default": [],
-      "title": "The repeating_languages Schema",
+      "title": "The Repeating Languages Section",
       "items": {
         "type": "object",
         "title": "A Schema",
         "required": [
-          "idkey",
-          "name",
-          "spoken",
-          "written",
-          "is_native"
+          "Idkey",
+          "Name",
+          "Spoken",
+          "Written",
+          "IsNative"
         ],
         "properties": {
-          "idkey": {
+          "Idkey": {
             "type": "string",
-            "title": "The idkey Schema",
+            "title": "The Idkey is the unique identifier, allowing the item to be easily re-imported.",
             "examples": [
-              "184",
-              "187",
-              "186"
+              "10663",
+              "12985",
+              "12984"
             ]
           },
-          "name": {
+          "Name": {
             "type": "string",
-            "title": "The name Schema",
+            "title": "The Name Schema",
             "examples": [
               "English",
-              "Spanish",
-              "Street Speach (Spoken)"
+              "French",
+              "German"
             ]
           },
-          "spoken": {
-            "type": "integer",
-            "title": "The spoken Schema",
+          "Spoken": {
+            "type": "number",
+            "title": "The Spoken Schema",
             "examples": [
-              3,
-              2
+              0.0,
+              2.0
             ]
           },
-          "written": {
-            "type": "integer",
-            "title": "The written Schema",
+          "Written": {
+            "type": "number",
+            "title": "The Written Schema",
             "examples": [
-              3,
-              2,
-              0
+              0.0,
+              1.0,
+              2.0
             ]
           },
-          "is_native": {
+          "IsNative": {
             "type": "boolean",
-            "title": "The is_native Schema",
+            "title": "The IsNative Schema",
             "examples": [
               true,
               false
@@ -812,314 +865,885 @@
         },
         "examples": [
           {
-            "idkey": "184",
-            "name": "English",
-            "spoken": 3,
-            "written": 3,
-            "is_native": true
+            "Idkey": "10663",
+            "Name": "English",
+            "Spoken": 0.0,
+            "Written": 0.0,
+            "IsNative": true
           },
           {
-            "idkey": "187",
-            "name": "Spanish",
-            "spoken": 2,
-            "written": 2,
-            "is_native": false
+            "Idkey": "12985",
+            "Name": "French",
+            "Spoken": 2.0,
+            "Written": 1.0,
+            "IsNative": false
           },
           {
-            "idkey": "186",
-            "name": "Street Speach (Spoken)",
-            "spoken": 2,
-            "written": 0,
-            "is_native": false
+            "Idkey": "12984",
+            "Name": "German",
+            "Spoken": 2.0,
+            "Written": 2.0,
+            "IsNative": false
           }
         ]
       },
       "examples": [
         [
           {
-            "idkey": "184",
-            "name": "English",
-            "spoken": 3,
-            "written": 3,
-            "is_native": true
+            "Idkey": "10663",
+            "Name": "English",
+            "Spoken": 0.0,
+            "Written": 0.0,
+            "IsNative": true
           },
           {
-            "idkey": "187",
-            "name": "Spanish",
-            "spoken": 2,
-            "written": 2,
-            "is_native": false
+            "Idkey": "12985",
+            "Name": "French",
+            "Spoken": 2.0,
+            "Written": 1.0,
+            "IsNative": false
           },
           {
-            "idkey": "186",
-            "name": "Street Speach (Spoken)",
-            "spoken": 2,
-            "written": 0,
-            "is_native": false
+            "Idkey": "12984",
+            "Name": "German",
+            "Spoken": 2.0,
+            "Written": 2.0,
+            "IsNative": false
           }
         ]
       ]
     },
-    "repeating_cultures": {
+    "RepeatingCultures": {
       "type": "array",
       "default": [],
-      "title": "The repeating_cultures Schema",
+      "title": "The RepeatingCultures Schema",
       "items": {
         "type": "object",
-        "default": {},
         "title": "A Schema",
         "required": [
-          "idkey",
-          "name",
-          "points"
+          "Idkey",
+          "Name",
+          "Points"
         ],
         "properties": {
-          "idkey": {
+          "Idkey": {
             "type": "string",
-            "default": "",
-            "title": "The idkey Schema",
+            "title": "The Idkey is the unique identifier, allowing the item to be easily re-imported.",
             "examples": [
-              ""
+              "12982",
+              "12983"
             ]
           },
-          "name": {
+          "Name": {
             "type": "string",
-            "default": "",
-            "title": "The name Schema",
+            "title": "The Name Schema",
             "examples": [
+              "European (Native)",
               "Western"
             ]
           },
-          "points": {
-            "type": "integer",
-            "default": 0,
-            "title": "The points Schema",
+          "Points": {
+            "type": "number",
+            "title": "The Points Schema",
             "examples": [
-              0
+              0.0,
+              1.0
             ]
           }
         },
         "examples": [
           {
-            "idkey": "",
-            "name": "Western",
-            "points": 0
+            "Idkey": "12982",
+            "Name": "European (Native)",
+            "Points": 0.0
+          },
+          {
+            "Idkey": "12983",
+            "Name": "Western",
+            "Points": 1.0
           }
         ]
       },
       "examples": [
         [
           {
-            "idkey": "",
-            "name": "Western",
-            "points": 0
+            "Idkey": "12982",
+            "Name": "European (Native)",
+            "Points": 0.0
+          },
+          {
+            "Idkey": "12983",
+            "Name": "Western",
+            "Points": 1.0
           }
         ]
       ]
     },
-    "repeating_traits": {
+    "RepeatingTraits": {
       "type": "array",
       "default": [],
-      "title": "The repeating_traits Schema",
+      "title": "The RepeatingTraits Schema",
       "items": {
         "type": "object",
         "title": "A Schema",
         "required": [
-          "idkey",
-          "name",
-          "trait_level",
-          "foa",
-          "points",
-          "ref",
-          "notes"
+          "Idkey",
+          "Name",
+          "TraitLevel",
+          "Foa",
+          "Points",
+          "Ref",
+          "Notes"
         ],
         "properties": {
-          "idkey": {
+          "Idkey": {
             "type": "string",
-            "title": "The idkey Schema",
+            "title": "The Idkey is the unique identifier, allowing the item to be easily re-imported.",
             "examples": [
-              "192",
-              "189",
-              "147"
+              "10717",
+              "10800",
+              "10704",
+              "10799",
+              "10698",
+              "12986",
+              "10720",
+              "10730",
+              "10741",
+              "10666",
+              "10700",
+              "10715",
+              "10702",
+              "10718",
+              "11893",
+              "10712",
+              "11891",
+              "10709",
+              "10714",
+              "10711",
+              "10705",
+              "10835",
+              "11890"
             ]
           },
-          "name": {
+          "Name": {
             "type": "string",
-            "title": "The name Schema",
+            "title": "The Name Schema",
             "examples": [
-              "Advanced Bionic Ear TL9",
-              "Contact (Cybernetic Street Engineer) (Effective Skill 12)",
-              "Danger Sense"
+              "Ambidexterity",
+              "Appearance",
+              "Body Control Talent",
+              "Charisma",
+              "Combat Reflexes",
+              "Contact (Rival Gang)",
+              "Crossbow (Armor Piercing)",
+              "Crossbow (Explosive)",
+              "Crossbow (Smoke Arrow)",
+              "Damage Resistance",
+              "Enhanced Dodge",
+              "Enhanced Move (Ground)",
+              "Enhanced Muscle",
+              "Extra Attack",
+              "Extra ST",
+              "Fit",
+              "Lifting ST",
+              "Protected Vision",
+              "Rapid Healing",
+              "Resilience",
+              "Resistant (Metabolic Hazards)",
+              "Signature Gear (Advanced Body Armor)",
+              "Wealth"
             ]
           },
-          "trait_level": {
+          "TraitLevel": {
             "type": "string",
-            "title": "The trait_level Schema",
+            "title": "The TraitLevel Schema",
             "examples": [
-              "1"
+              "1",
+              "2",
+              "3",
+              "6",
+              "4",
+              "20"
             ]
           },
-          "foa": {
+          "Foa": {
             "type": "string",
-            "title": "The foa Schema",
+            "title": "The Foa Schema",
             "examples": [
               "",
               "9"
             ]
           },
-          "points": {
-            "type": "integer",
-            "title": "The points Schema",
+          "Points": {
+            "type": "number",
+            "title": "The Points Schema",
             "examples": [
-              11,
-              1,
-              15
+              5.0,
+              4.0,
+              10.0,
+              14.0,
+              1.0,
+              38.0,
+              7.0,
+              9.0,
+              29.0,
+              23.0,
+              18.0
             ]
           },
-          "ref": {
+          "Ref": {
             "type": "string",
-            "title": "The ref Schema",
+            "title": "The Ref Schema",
             "examples": [
+              "B39",
+              "B21",
+              "P121,P167-169",
+              "B41",
+              "B43",
               "B44",
-              "B47"
+              "B61, P53",
+              "B72, P64",
+              "B46, P45",
+              "B51",
+              "B52, P49",
+              "Bio213",
+              "B54, P49",
+              "B14",
+              "B55",
+              "B65, P58",
+              "B78, P69",
+              "B79",
+              "",
+              "B80, P71",
+              "B85",
+              "B25"
             ]
           },
-          "notes": {
+          "Notes": {
             "type": "string",
-            "title": "The notes Schema",
+            "title": "The Notes Schema",
             "examples": [
-              "Based On: _New Advanage\n\nDiscriminatory Hearing (Temporary Disadvantage, Electrical, -20%)[12];Protected Hearing[5];Deafness (Mitigator -70%)[-6]",
-              "Modifiers:\nFrequency: roll of 9 or less, *1\nReliability: Somewhat Reliable, *1",
-              ""
+              "",
+              "Attractive",
+              "Innate Attack (Projectile), +0",
+              "Biological, -10%",
+              "My notes here\nEffective Skill 12\nRival Gang\n9 or less, *1\nSomewhat Reliable, *1\nMy notes here\nUgly dude with twisted lips",
+              "Armor Piercing\nArmor Divisor, 2, +50%\nGadget/Breakable: DR 3-5, -15%\nGadget/Breakable: Size -3 or -4, -15%\nGadget/Can Be Stolen: Must be forcefully removed, -10%\nInaccurate, -1, -5%\nIncreased Range, x2, +10%\nIncreased Range, 1/2D Range only, x5, +10%\nNo Signature, +20%\nRicochet, +10%",
+              "Explosive\nAlternative Attack, *1/5\nDouble Knockback, +20%\nExplosive, Damage / 2xYards, +100%\nGadget/Breakable: DR 3-5, -15%\nGadget/Breakable: Size -3 or -4, -15%\nGadget/Can Be Stolen: Must be forcefully removed, -10%\nInaccurate, -1, -5%\nIncreased Range, x2, +10%\nIncreased Range, 1/2D Range only, x10, +15%\nNo Signature, +20%",
+              "Smoke Arrow\nAlternative Ability, *1/5\nArea Effect, 4 yd, +50%\nGadget/Breakable: DR 3-5, -15%\nGadget/Breakable: Size -3 or -4, -15%\nGadget/Can Be Stolen: Must be forcefully removed, -10%\nInaccurate, -1, -5%\nIncreased Range, x2, +10%\nIncreased Range, 1/2D Range Only, x5, +10%\nNo Signature, +20%\nRanged, +50%",
+              "Biological, -10%\nTough Skin, -40%",
+              "#list(LevelName Step 0.5)\nGround\nBiological, -10%",
+              "Affects ST, +0%\nSize, +0%\nThe Extra ST advantage allows you to take extra levels of the attribute which you can then apply enhancements and limitations to. The \"Affects displayed score\" modifier causes the Extra ST advantage to affect the displayed attribute score. If you don't wish this advantage to affect the displayed score remove that modifier.",
+              "Size, +0%",
+              "Very Common\nMetabolic Hazards\nBiological, -10%\n+3, *1/3",
+              "%SigGearAliasList%\nAdvanced Body Armor",
+              "Comfortable"
             ]
           }
         },
         "examples": [
           {
-            "idkey": "192",
-            "name": "Advanced Bionic Ear TL9",
-            "trait_level": "1",
-            "foa": "",
-            "points": 11,
-            "ref": "B44",
-            "notes": "Based On: _New Advanage\n\nDiscriminatory Hearing (Temporary Disadvantage, Electrical, -20%)[12];Protected Hearing[5];Deafness (Mitigator -70%)[-6]"
+            "Idkey": "10717",
+            "Name": "Ambidexterity",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "B39",
+            "Notes": ""
           },
           {
-            "idkey": "189",
-            "name": "Contact (Cybernetic Street Engineer) (Effective Skill 12)",
-            "trait_level": "1",
-            "foa": "9",
-            "points": 1,
-            "ref": "B44",
-            "notes": "Modifiers:\nFrequency: roll of 9 or less, *1\nReliability: Somewhat Reliable, *1"
+            "Idkey": "10800",
+            "Name": "Appearance",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 4.0,
+            "Ref": "B21",
+            "Notes": "Attractive"
           },
           {
-            "idkey": "147",
-            "name": "Danger Sense",
-            "trait_level": "1",
-            "foa": "",
-            "points": 15,
-            "ref": "B47",
-            "notes": ""
+            "Idkey": "10704",
+            "Name": "Body Control Talent",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "P121,P167-169",
+            "Notes": "Innate Attack (Projectile), +0"
+          },
+          {
+            "Idkey": "10799",
+            "Name": "Charisma",
+            "TraitLevel": "2",
+            "Foa": "",
+            "Points": 10.0,
+            "Ref": "B41",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10698",
+            "Name": "Combat Reflexes",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 14.0,
+            "Ref": "B43",
+            "Notes": "Biological, -10%"
+          },
+          {
+            "Idkey": "12986",
+            "Name": "Contact (Rival Gang)",
+            "TraitLevel": "1",
+            "Foa": "9",
+            "Points": 1.0,
+            "Ref": "B44",
+            "Notes": "My notes here\nEffective Skill 12\nRival Gang\n9 or less, *1\nSomewhat Reliable, *1\nMy notes here\nUgly dude with twisted lips"
+          },
+          {
+            "Idkey": "10720",
+            "Name": "Crossbow (Armor Piercing)",
+            "TraitLevel": "3",
+            "Foa": "",
+            "Points": 38.0,
+            "Ref": "B61, P53",
+            "Notes": "Armor Piercing\nArmor Divisor, 2, +50%\nGadget/Breakable: DR 3-5, -15%\nGadget/Breakable: Size -3 or -4, -15%\nGadget/Can Be Stolen: Must be forcefully removed, -10%\nInaccurate, -1, -5%\nIncreased Range, x2, +10%\nIncreased Range, 1/2D Range only, x5, +10%\nNo Signature, +20%\nRicochet, +10%"
+          },
+          {
+            "Idkey": "10730",
+            "Name": "Crossbow (Explosive)",
+            "TraitLevel": "3",
+            "Foa": "",
+            "Points": 7.0,
+            "Ref": "B61, P53",
+            "Notes": "Explosive\nAlternative Attack, *1/5\nDouble Knockback, +20%\nExplosive, Damage / 2xYards, +100%\nGadget/Breakable: DR 3-5, -15%\nGadget/Breakable: Size -3 or -4, -15%\nGadget/Can Be Stolen: Must be forcefully removed, -10%\nInaccurate, -1, -5%\nIncreased Range, x2, +10%\nIncreased Range, 1/2D Range only, x10, +15%\nNo Signature, +20%"
+          },
+          {
+            "Idkey": "10741",
+            "Name": "Crossbow (Smoke Arrow)",
+            "TraitLevel": "6",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "B72, P64",
+            "Notes": "Smoke Arrow\nAlternative Ability, *1/5\nArea Effect, 4 yd, +50%\nGadget/Breakable: DR 3-5, -15%\nGadget/Breakable: Size -3 or -4, -15%\nGadget/Can Be Stolen: Must be forcefully removed, -10%\nInaccurate, -1, -5%\nIncreased Range, x2, +10%\nIncreased Range, 1/2D Range Only, x5, +10%\nNo Signature, +20%\nRanged, +50%"
+          },
+          {
+            "Idkey": "10666",
+            "Name": "Damage Resistance",
+            "TraitLevel": "2",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "B46, P45",
+            "Notes": "Biological, -10%\nTough Skin, -40%"
+          },
+          {
+            "Idkey": "10700",
+            "Name": "Enhanced Dodge",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 14.0,
+            "Ref": "B51",
+            "Notes": "Biological, -10%"
+          },
+          {
+            "Idkey": "10715",
+            "Name": "Enhanced Move (Ground)",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 9.0,
+            "Ref": "B52, P49",
+            "Notes": "#list(LevelName Step 0.5)\nGround\nBiological, -10%"
+          },
+          {
+            "Idkey": "10702",
+            "Name": "Enhanced Muscle",
+            "TraitLevel": "4",
+            "Foa": "",
+            "Points": 29.0,
+            "Ref": "Bio213",
+            "Notes": "Biological, -10%"
+          },
+          {
+            "Idkey": "10718",
+            "Name": "Extra Attack",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 23.0,
+            "Ref": "B54, P49",
+            "Notes": "Biological, -10%"
+          },
+          {
+            "Idkey": "11893",
+            "Name": "Extra ST",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 10.0,
+            "Ref": "B14",
+            "Notes": "Affects ST, +0%\nSize, +0%\nThe Extra ST advantage allows you to take extra levels of the attribute which you can then apply enhancements and limitations to. The \"Affects displayed score\" modifier causes the Extra ST advantage to affect the displayed attribute score. If you don't wish this advantage to affect the displayed score remove that modifier."
+          },
+          {
+            "Idkey": "10712",
+            "Name": "Fit",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "B55",
+            "Notes": ""
+          },
+          {
+            "Idkey": "11891",
+            "Name": "Lifting ST",
+            "TraitLevel": "3",
+            "Foa": "",
+            "Points": 9.0,
+            "Ref": "B65, P58",
+            "Notes": "Size, +0%"
+          },
+          {
+            "Idkey": "10709",
+            "Name": "Protected Vision",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "B78, P69",
+            "Notes": "Biological, -10%"
+          },
+          {
+            "Idkey": "10714",
+            "Name": "Rapid Healing",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "B79",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10711",
+            "Name": "Resilience",
+            "TraitLevel": "20",
+            "Foa": "",
+            "Points": 18.0,
+            "Ref": "",
+            "Notes": "Biological, -10%"
+          },
+          {
+            "Idkey": "10705",
+            "Name": "Resistant (Metabolic Hazards)",
+            "TraitLevel": "4",
+            "Foa": "",
+            "Points": 9.0,
+            "Ref": "B80, P71",
+            "Notes": "Very Common\nMetabolic Hazards\nBiological, -10%\n+3, *1/3"
+          },
+          {
+            "Idkey": "10835",
+            "Name": "Signature Gear (Advanced Body Armor)",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 1.0,
+            "Ref": "B85",
+            "Notes": "%SigGearAliasList%\nAdvanced Body Armor"
+          },
+          {
+            "Idkey": "11890",
+            "Name": "Wealth",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 10.0,
+            "Ref": "B25",
+            "Notes": "Comfortable"
           }
         ]
       },
       "examples": [
         [
           {
-            "idkey": "192",
-            "name": "Advanced Bionic Ear TL9",
-            "trait_level": "1",
-            "foa": "",
-            "points": 11,
-            "ref": "B44",
-            "notes": "Based On: _New Advanage\n\nDiscriminatory Hearing (Temporary Disadvantage, Electrical, -20%)[12];Protected Hearing[5];Deafness (Mitigator -70%)[-6]"
+            "Idkey": "10717",
+            "Name": "Ambidexterity",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "B39",
+            "Notes": ""
           },
           {
-            "idkey": "189",
-            "name": "Contact (Cybernetic Street Engineer) (Effective Skill 12)",
-            "trait_level": "1",
-            "foa": "9",
-            "points": 1,
-            "ref": "B44",
-            "notes": "Modifiers:\nFrequency: roll of 9 or less, *1\nReliability: Somewhat Reliable, *1"
+            "Idkey": "10800",
+            "Name": "Appearance",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 4.0,
+            "Ref": "B21",
+            "Notes": "Attractive"
           },
           {
-            "idkey": "147",
-            "name": "Danger Sense",
-            "trait_level": "1",
-            "foa": "",
-            "points": 15,
-            "ref": "B47",
-            "notes": ""
+            "Idkey": "10704",
+            "Name": "Body Control Talent",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "P121,P167-169",
+            "Notes": "Innate Attack (Projectile), +0"
+          },
+          {
+            "Idkey": "10799",
+            "Name": "Charisma",
+            "TraitLevel": "2",
+            "Foa": "",
+            "Points": 10.0,
+            "Ref": "B41",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10698",
+            "Name": "Combat Reflexes",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 14.0,
+            "Ref": "B43",
+            "Notes": "Biological, -10%"
+          },
+          {
+            "Idkey": "12986",
+            "Name": "Contact (Rival Gang)",
+            "TraitLevel": "1",
+            "Foa": "9",
+            "Points": 1.0,
+            "Ref": "B44",
+            "Notes": "My notes here\nEffective Skill 12\nRival Gang\n9 or less, *1\nSomewhat Reliable, *1\nMy notes here\nUgly dude with twisted lips"
+          },
+          {
+            "Idkey": "10720",
+            "Name": "Crossbow (Armor Piercing)",
+            "TraitLevel": "3",
+            "Foa": "",
+            "Points": 38.0,
+            "Ref": "B61, P53",
+            "Notes": "Armor Piercing\nArmor Divisor, 2, +50%\nGadget/Breakable: DR 3-5, -15%\nGadget/Breakable: Size -3 or -4, -15%\nGadget/Can Be Stolen: Must be forcefully removed, -10%\nInaccurate, -1, -5%\nIncreased Range, x2, +10%\nIncreased Range, 1/2D Range only, x5, +10%\nNo Signature, +20%\nRicochet, +10%"
+          },
+          {
+            "Idkey": "10730",
+            "Name": "Crossbow (Explosive)",
+            "TraitLevel": "3",
+            "Foa": "",
+            "Points": 7.0,
+            "Ref": "B61, P53",
+            "Notes": "Explosive\nAlternative Attack, *1/5\nDouble Knockback, +20%\nExplosive, Damage / 2xYards, +100%\nGadget/Breakable: DR 3-5, -15%\nGadget/Breakable: Size -3 or -4, -15%\nGadget/Can Be Stolen: Must be forcefully removed, -10%\nInaccurate, -1, -5%\nIncreased Range, x2, +10%\nIncreased Range, 1/2D Range only, x10, +15%\nNo Signature, +20%"
+          },
+          {
+            "Idkey": "10741",
+            "Name": "Crossbow (Smoke Arrow)",
+            "TraitLevel": "6",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "B72, P64",
+            "Notes": "Smoke Arrow\nAlternative Ability, *1/5\nArea Effect, 4 yd, +50%\nGadget/Breakable: DR 3-5, -15%\nGadget/Breakable: Size -3 or -4, -15%\nGadget/Can Be Stolen: Must be forcefully removed, -10%\nInaccurate, -1, -5%\nIncreased Range, x2, +10%\nIncreased Range, 1/2D Range Only, x5, +10%\nNo Signature, +20%\nRanged, +50%"
+          },
+          {
+            "Idkey": "10666",
+            "Name": "Damage Resistance",
+            "TraitLevel": "2",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "B46, P45",
+            "Notes": "Biological, -10%\nTough Skin, -40%"
+          },
+          {
+            "Idkey": "10700",
+            "Name": "Enhanced Dodge",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 14.0,
+            "Ref": "B51",
+            "Notes": "Biological, -10%"
+          },
+          {
+            "Idkey": "10715",
+            "Name": "Enhanced Move (Ground)",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 9.0,
+            "Ref": "B52, P49",
+            "Notes": "#list(LevelName Step 0.5)\nGround\nBiological, -10%"
+          },
+          {
+            "Idkey": "10702",
+            "Name": "Enhanced Muscle",
+            "TraitLevel": "4",
+            "Foa": "",
+            "Points": 29.0,
+            "Ref": "Bio213",
+            "Notes": "Biological, -10%"
+          },
+          {
+            "Idkey": "10718",
+            "Name": "Extra Attack",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 23.0,
+            "Ref": "B54, P49",
+            "Notes": "Biological, -10%"
+          },
+          {
+            "Idkey": "11893",
+            "Name": "Extra ST",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 10.0,
+            "Ref": "B14",
+            "Notes": "Affects ST, +0%\nSize, +0%\nThe Extra ST advantage allows you to take extra levels of the attribute which you can then apply enhancements and limitations to. The \"Affects displayed score\" modifier causes the Extra ST advantage to affect the displayed attribute score. If you don't wish this advantage to affect the displayed score remove that modifier."
+          },
+          {
+            "Idkey": "10712",
+            "Name": "Fit",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "B55",
+            "Notes": ""
+          },
+          {
+            "Idkey": "11891",
+            "Name": "Lifting ST",
+            "TraitLevel": "3",
+            "Foa": "",
+            "Points": 9.0,
+            "Ref": "B65, P58",
+            "Notes": "Size, +0%"
+          },
+          {
+            "Idkey": "10709",
+            "Name": "Protected Vision",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "B78, P69",
+            "Notes": "Biological, -10%"
+          },
+          {
+            "Idkey": "10714",
+            "Name": "Rapid Healing",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 5.0,
+            "Ref": "B79",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10711",
+            "Name": "Resilience",
+            "TraitLevel": "20",
+            "Foa": "",
+            "Points": 18.0,
+            "Ref": "",
+            "Notes": "Biological, -10%"
+          },
+          {
+            "Idkey": "10705",
+            "Name": "Resistant (Metabolic Hazards)",
+            "TraitLevel": "4",
+            "Foa": "",
+            "Points": 9.0,
+            "Ref": "B80, P71",
+            "Notes": "Very Common\nMetabolic Hazards\nBiological, -10%\n+3, *1/3"
+          },
+          {
+            "Idkey": "10835",
+            "Name": "Signature Gear (Advanced Body Armor)",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 1.0,
+            "Ref": "B85",
+            "Notes": "%SigGearAliasList%\nAdvanced Body Armor"
+          },
+          {
+            "Idkey": "11890",
+            "Name": "Wealth",
+            "TraitLevel": "1",
+            "Foa": "",
+            "Points": 10.0,
+            "Ref": "B25",
+            "Notes": "Comfortable"
           }
         ]
       ]
     },
-    "repeating_perks": {
+    "RepeatingPerks": {
       "type": "array",
       "default": [],
-      "title": "The repeating_perks Schema",
+      "title": "The RepeatingPerks Schema",
       "items": {
         "type": "object",
         "title": "A Schema",
         "required": [
-          "idkey",
-          "name",
-          "foa",
-          "points",
-          "ref",
-          "notes"
+          "Idkey",
+          "Name",
+          "Foa",
+          "Points",
+          "Ref",
+          "Notes"
         ],
         "properties": {
-          "idkey": {
+          "Idkey": {
             "type": "string",
-            "title": "The idkey Schema",
+            "title": "The Idkey is the unique identifier, allowing the item to be easily re-imported.",
             "examples": [
-              "129",
-              "204",
-              "205",
-              "202"
+              "10756",
+              "10757",
+              "10794"
             ]
           },
-          "name": {
+          "Name": {
             "type": "string",
-            "title": "The name Schema",
+            "title": "The Name Schema",
             "examples": [
               "Alcohol Tolerance",
-              "Forgettable Face",
-              "Illegal Gear - AP Bullets",
-              "License (Holdout Pistol)"
+              "Base (Bar)",
+              "Teamwork (Concrete Savages)"
             ]
           },
-          "foa": {
+          "Foa": {
             "type": "string",
-            "title": "The foa Schema",
+            "title": "The Foa Schema",
             "examples": [
-              "",
-              "12"
+              ""
             ]
           },
-          "points": {
-            "type": "integer",
-            "title": "The points Schema",
+          "Points": {
+            "type": "number",
+            "title": "The Points Schema",
             "examples": [
-              1
+              1.0
             ]
           },
-          "ref": {
+          "Ref": {
             "type": "string",
-            "title": "The ref Schema",
+            "title": "The Ref Schema",
             "examples": [
               "B100, B100,PU2:13",
-              "PU2:4",
+              "PU2:17",
+              "MA52, PU2:6"
+            ]
+          },
+          "Notes": {
+            "type": "string",
+            "title": "The Notes Schema",
+            "examples": [
               "",
-              "PU2:18"
+              "Bar",
+              "Concrete Savages"
+            ]
+          }
+        },
+        "examples": [
+          {
+            "Idkey": "10756",
+            "Name": "Alcohol Tolerance",
+            "Foa": "",
+            "Points": 1.0,
+            "Ref": "B100, B100,PU2:13",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10757",
+            "Name": "Base (Bar)",
+            "Foa": "",
+            "Points": 1.0,
+            "Ref": "PU2:17",
+            "Notes": "Bar"
+          },
+          {
+            "Idkey": "10794",
+            "Name": "Teamwork (Concrete Savages)",
+            "Foa": "",
+            "Points": 1.0,
+            "Ref": "MA52, PU2:6",
+            "Notes": "Concrete Savages"
+          }
+        ]
+      },
+      "examples": [
+        [
+          {
+            "Idkey": "10756",
+            "Name": "Alcohol Tolerance",
+            "Foa": "",
+            "Points": 1.0,
+            "Ref": "B100, B100,PU2:13",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10757",
+            "Name": "Base (Bar)",
+            "Foa": "",
+            "Points": 1.0,
+            "Ref": "PU2:17",
+            "Notes": "Bar"
+          },
+          {
+            "Idkey": "10794",
+            "Name": "Teamwork (Concrete Savages)",
+            "Foa": "",
+            "Points": 1.0,
+            "Ref": "MA52, PU2:6",
+            "Notes": "Concrete Savages"
+          }
+        ]
+      ]
+    },
+    "RepeatingQuirks": {
+      "type": "array",
+      "default": [],
+      "title": "The RepeatingQuirks Schema",
+      "items": {
+        "type": "object",
+        "title": "A Schema",
+        "required": [
+          "Idkey",
+          "Name",
+          "ControlRating",
+          "Points",
+          "Ref",
+          "Notes"
+        ],
+        "properties": {
+          "Idkey": {
+            "type": "string",
+            "title": "The Idkey is the unique identifier, allowing the item to be easily re-imported.",
+            "examples": [
+              "10774",
+              "10773"
             ]
           },
-          "notes": {
+          "Name": {
             "type": "string",
-            "title": "The notes Schema",
+            "title": "The Name Schema",
+            "examples": [
+              "Chauvinistic",
+              "wears chains"
+            ]
+          },
+          "ControlRating": {
+            "type": "string",
+            "title": "The ControlRating Schema",
+            "examples": [
+              ""
+            ]
+          },
+          "Points": {
+            "type": "number",
+            "title": "The Points Schema",
+            "examples": [
+              "-",
+              1.0
+            ]
+          },
+          "Ref": {
+            "type": "string",
+            "title": "The Ref Schema",
+            "examples": [
+              "B164",
+              ""
+            ]
+          },
+          "Notes": {
+            "type": "string",
+            "title": "The Notes Schema",
             "examples": [
               ""
             ]
@@ -1127,849 +1751,1106 @@
         },
         "examples": [
           {
-            "idkey": "129",
-            "name": "Alcohol Tolerance",
-            "foa": "",
-            "points": 1,
-            "ref": "B100, B100,PU2:13",
-            "notes": ""
+            "Idkey": "10774",
+            "Name": "Chauvinistic",
+            "ControlRating": "",
+            "Points": "-",
+            1.0,
+            "Ref": "B164",
+            "Notes": ""
           },
           {
-            "idkey": "204",
-            "name": "Forgettable Face",
-            "foa": "12",
-            "points": 1,
-            "ref": "PU2:4",
-            "notes": ""
-          },
-          {
-            "idkey": "205",
-            "name": "Illegal Gear - AP Bullets",
-            "foa": "",
-            "points": 1,
-            "ref": "",
-            "notes": ""
-          },
-          {
-            "idkey": "202",
-            "name": "License (Holdout Pistol)",
-            "foa": "",
-            "points": 1,
-            "ref": "PU2:18",
-            "notes": ""
+            "Idkey": "10773",
+            "Name": "wears chains",
+            "ControlRating": "",
+            "Points": "-",
+            1.0,
+            "Ref": "",
+            "Notes": ""
           }
         ]
       },
       "examples": [
         [
           {
-            "idkey": "129",
-            "name": "Alcohol Tolerance",
-            "foa": "",
-            "points": 1,
-            "ref": "B100, B100,PU2:13",
-            "notes": ""
+            "Idkey": "10774",
+            "Name": "Chauvinistic",
+            "ControlRating": "",
+            "Points": "-",
+            1.0,
+            "Ref": "B164",
+            "Notes": ""
           },
           {
-            "idkey": "204",
-            "name": "Forgettable Face",
-            "foa": "12",
-            "points": 1,
-            "ref": "PU2:4",
-            "notes": ""
-          },
-          {
-            "idkey": "205",
-            "name": "Illegal Gear - AP Bullets",
-            "foa": "",
-            "points": 1,
-            "ref": "",
-            "notes": ""
-          },
-          {
-            "idkey": "202",
-            "name": "License (Holdout Pistol)",
-            "foa": "",
-            "points": 1,
-            "ref": "PU2:18",
-            "notes": ""
+            "Idkey": "10773",
+            "Name": "wears chains",
+            "ControlRating": "",
+            "Points": "-",
+            1.0,
+            "Ref": "",
+            "Notes": ""
           }
         ]
       ]
     },
-    "repeating_quirks": {
+    "RepeatingDisadvantages": {
       "type": "array",
       "default": [],
-      "title": "The repeating_quirks Schema",
+      "title": "The RepeatingDisadvantages Schema",
       "items": {
         "type": "object",
         "title": "A Schema",
         "required": [
-          "idkey",
-          "name",
-          "control_rating",
-          "points",
-          "ref",
-          "notes"
+          "Idkey",
+          "Name",
+          "TraitLevel",
+          "ControlRating",
+          "Points",
+          "Ref",
+          "Notes"
         ],
         "properties": {
-          "idkey": {
+          "Idkey": {
             "type": "string",
-            "title": "The idkey Schema",
+            "title": "The Idkey is the unique identifier, allowing the item to be easily re-imported.",
             "examples": [
-              "216",
-              "217",
-              "169"
+              "10758",
+              "10769",
+              "10760",
+              "10762"
             ]
           },
-          "name": {
+          "Name": {
             "type": "string",
-            "title": "The name Schema",
-            "examples": [
-              "Avoids the spying on spouse jobs",
-              "Careful",
-              "Will use whatever provides upper hand"
-            ]
-          },
-          "control_rating": {
-            "type": "string",
-            "title": "The control_rating Schema",
-            "examples": [
-              "12",
-              ""
-            ]
-          },
-          "points": {
-            "type": "integer",
-            "title": "The points Schema",
-            "examples": [
-              "-1"
-            ]
-          },
-          "ref": {
-            "type": "string",
-            "title": "The ref Schema",
-            "examples": [
-              "B163",
-              "B164"
-            ]
-          },
-          "notes": {
-            "type": "string",
-            "title": "The notes Schema",
-            "examples": [
-              ""
-            ]
-          }
-        },
-        "examples": [
-          {
-            "idkey": "216",
-            "name": "Avoids the spying on spouse jobs",
-            "control_rating": "12",
-            "points": "-1",
-            "ref": "B163",
-            "notes": ""
-          },
-          {
-            "idkey": "217",
-            "name": "Careful",
-            "control_rating": "",
-            "points": "-1",
-            "ref": "B164",
-            "notes": ""
-          },
-          {
-            "idkey": "169",
-            "name": "Will use whatever provides upper hand",
-            "control_rating": "",
-            "points": "-1",
-            "ref": "B163",
-            "notes": ""
-          }
-        ]
-      },
-      "examples": [
-        [
-          {
-            "idkey": "216",
-            "name": "Avoids the spying on spouse jobs",
-            "control_rating": "12",
-            "points": "-1",
-            "ref": "B163",
-            "notes": ""
-          },
-          {
-            "idkey": "217",
-            "name": "Careful",
-            "control_rating": "",
-            "points": "-1",
-            "ref": "B164",
-            "notes": ""
-          },
-          {
-            "idkey": "169",
-            "name": "Will use whatever provides upper hand",
-            "control_rating": "",
-            "points": "-1",
-            "ref": "B163",
-            "notes": ""
-          }
-        ]
-      ]
-    },
-    "repeating_disadvantages": {
-      "type": "array",
-      "default": [],
-      "title": "The repeating_disadvantages Schema",
-      "items": {
-        "type": "object",
-        "title": "A Schema",
-        "required": [
-          "idkey",
-          "name",
-          "trait_level",
-          "control_rating",
-          "points",
-          "ref",
-          "notes"
-        ],
-        "properties": {
-          "idkey": {
-            "type": "string",
-            "title": "The idkey Schema",
-            "examples": [
-              "159",
-              "164"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "title": "The name Schema",
-            "examples": [
-              "Addiction (Alcohol) (Cheap)",
-              "Code of Honor (Professional)"
-            ]
-          },
-          "trait_level": {
-            "type": "string",
-            "title": "The trait_level Schema",
-            "examples": [
-              "1"
-            ]
-          },
-          "control_rating": {
-            "type": "string",
-            "title": "The control_rating Schema",
-            "examples": [
-              "12",
-              ""
-            ]
-          },
-          "points": {
-            "type": "integer",
-            "title": "The points Schema",
-            "examples": [
-              "-10",
-              "-5"
-            ]
-          },
-          "ref": {
-            "type": "string",
-            "title": "The ref Schema",
-            "examples": [
-              "B122",
-              "B127"
-            ]
-          },
-          "notes": {
-            "type": "string",
-            "title": "The notes Schema",
-            "examples": [
-              "Modifiers:\nEffect: Incapacitating, 10\nLegality: Legal, +5",
-              ""
-            ]
-          }
-        },
-        "examples": [
-          {
-            "idkey": "159",
-            "name": "Addiction (Alcohol) (Cheap)",
-            "trait_level": "1",
-            "control_rating": "12",
-            "points": "-10",
-            "ref": "B122",
-            "notes": "Modifiers:\nEffect: Incapacitating, 10\nLegality: Legal, +5"
-          },
-          {
-            "idkey": "164",
-            "name": "Code of Honor (Professional)",
-            "trait_level": "1",
-            "control_rating": "",
-            "points": "-5",
-            "ref": "B127",
-            "notes": ""
-          }
-        ]
-      },
-      "examples": [
-        [
-          {
-            "idkey": "159",
-            "name": "Addiction (Alcohol) (Cheap)",
-            "trait_level": "1",
-            "control_rating": "12",
-            "points": "-10",
-            "ref": "B122",
-            "notes": "Modifiers:\nEffect: Incapacitating, 10\nLegality: Legal, +5"
-          },
-          {
-            "idkey": "164",
-            "name": "Code of Honor (Professional)",
-            "trait_level": "1",
-            "control_rating": "",
-            "points": "-5",
-            "ref": "B127",
-            "notes": ""
-          }
-        ]
-      ]
-    },
-    "repeating_racial": {
-      "type": "array",
-      "default": [],
-      "title": "The repeating_racial Schema",
-      "items": {
-        "type": "object",
-        "title": "A Schema",
-        "required": [
-          "idkey",
-          "name",
-          "trait_level",
-          "control_rating",
-          "points",
-          "ref",
-          "notes"
-        ],
-        "properties": {
-          "idkey": {
-            "type": "string",
-            "title": "The idkey Schema",
-            "examples": [
-              ""
-            ]
-          },
-          "name": {
-            "type": "string",
-            "title": "The name Schema",
+            "title": "The Name Schema",
             "examples": [
               "Bad Temper",
-              "Strong Will"
+              "Enemy (Police)",
+              "Greed",
+              "Reputation (Gang Leader)"
             ]
           },
-          "trait_level": {
+          "TraitLevel": {
             "type": "string",
-            "title": "The trait_level Schema",
+            "title": "The TraitLevel Schema",
             "examples": [
-              "",
-              "1"
+              "1",
+              "2"
             ]
           },
-          "control_rating": {
+          "ControlRating": {
             "type": "string",
-            "title": "The control_rating Schema",
+            "title": "The ControlRating Schema",
             "examples": [
               "12",
               ""
             ]
           },
-          "points": {
-            "type": "integer",
-            "title": "The points Schema",
+          "Points": {
+            "type": "number",
+            "title": "The Points Schema",
             "examples": [
-              "-5",
-              5
+              "-",
+              10.0,
+              "-",
+              15.0,
+              "-",
+              1.0
             ]
           },
-          "ref": {
+          "Ref": {
             "type": "string",
-            "title": "The ref Schema",
+            "title": "The Ref Schema",
             "examples": [
-              ""
+              "B124",
+              "B135",
+              "B137",
+              "B27"
             ]
           },
-          "notes": {
+          "Notes": {
             "type": "string",
-            "title": "The notes Schema",
+            "title": "The Notes Schema",
             "examples": [
-              ""
+              "12 or less, *1",
+              "Small group (3-5 people)\nPolice\n9 or less, *1\nHunter, *1",
+              "Gang Leader\n7 or less, *1/3\nLarge class, *1/2"
             ]
           }
         },
         "examples": [
           {
-            "idkey": "",
-            "name": "Bad Temper",
-            "trait_level": "",
-            "control_rating": "12",
-            "points": "-5",
-            "ref": "",
-            "notes": ""
+            "Idkey": "10758",
+            "Name": "Bad Temper",
+            "TraitLevel": "1",
+            "ControlRating": "12",
+            "Points": "-",
+            10.0,
+            "Ref": "B124",
+            "Notes": "12 or less, *1"
           },
           {
-            "idkey": "",
-            "name": "Strong Will",
-            "trait_level": "1",
-            "control_rating": "",
-            "points": 5,
-            "ref": "",
-            "notes": ""
+            "Idkey": "10769",
+            "Name": "Enemy (Police)",
+            "TraitLevel": "1",
+            "ControlRating": "",
+            "Points": "-",
+            10.0,
+            "Ref": "B135",
+            "Notes": "Small group (3-5 people)\nPolice\n9 or less, *1\nHunter, *1"
+          },
+          {
+            "Idkey": "10760",
+            "Name": "Greed",
+            "TraitLevel": "1",
+            "ControlRating": "12",
+            "Points": "-",
+            15.0,
+            "Ref": "B137",
+            "Notes": "12 or less, *1"
+          },
+          {
+            "Idkey": "10762",
+            "Name": "Reputation (Gang Leader)",
+            "TraitLevel": "2",
+            "ControlRating": "",
+            "Points": "-",
+            1.0,
+            "Ref": "B27",
+            "Notes": "Gang Leader\n7 or less, *1/3\nLarge class, *1/2"
           }
         ]
       },
       "examples": [
         [
           {
-            "idkey": "",
-            "name": "Bad Temper",
-            "trait_level": "",
-            "control_rating": "12",
-            "points": "-5",
-            "ref": "",
-            "notes": ""
+            "Idkey": "10758",
+            "Name": "Bad Temper",
+            "TraitLevel": "1",
+            "ControlRating": "12",
+            "Points": "-",
+            10.0,
+            "Ref": "B124",
+            "Notes": "12 or less, *1"
           },
           {
-            "idkey": "",
-            "name": "Strong Will",
-            "trait_level": "1",
-            "control_rating": "",
-            "points": 5,
-            "ref": "",
-            "notes": ""
+            "Idkey": "10769",
+            "Name": "Enemy (Police)",
+            "TraitLevel": "1",
+            "ControlRating": "",
+            "Points": "-",
+            10.0,
+            "Ref": "B135",
+            "Notes": "Small group (3-5 people)\nPolice\n9 or less, *1\nHunter, *1"
+          },
+          {
+            "Idkey": "10760",
+            "Name": "Greed",
+            "TraitLevel": "1",
+            "ControlRating": "12",
+            "Points": "-",
+            15.0,
+            "Ref": "B137",
+            "Notes": "12 or less, *1"
+          },
+          {
+            "Idkey": "10762",
+            "Name": "Reputation (Gang Leader)",
+            "TraitLevel": "2",
+            "ControlRating": "",
+            "Points": "-",
+            1.0,
+            "Ref": "B27",
+            "Notes": "Gang Leader\n7 or less, *1/3\nLarge class, *1/2"
           }
         ]
       ]
     },
-    "repeating_skills": {
+    "RepeatingRacial": {
       "type": "array",
       "default": [],
-      "title": "The repeating_skills Schema",
+      "title": "The RepeatingRacial Schema",
+      "items": {},
+      "examples": [
+        []
+      ]
+    },
+    "RepeatingSkills": {
+      "type": "array",
+      "default": [],
+      "title": "The RepeatingSkills Schema",
       "items": {
         "type": "object",
         "title": "A Schema",
         "required": [
-          "idkey",
-          "name",
-          "tl",
-          "base",
-          "difficulty",
-          "bonus",
-          "points",
-          "skill",
-          "use_wildcard_points",
-          "use_normal_points",
-          "wildcard_skill_points",
-          "ref",
-          "skill_mod_notes",
-          "notes"
+          "Idkey",
+          "Name",
+          "Tl",
+          "Base",
+          "Difficulty",
+          "Bonus",
+          "Points",
+          "Skill",
+          "Ref",
+          "SkillModNotes",
+          "Notes"
         ],
         "properties": {
-          "idkey": {
+          "Idkey": {
             "type": "string",
-            "title": "The idkey Schema",
+            "title": "The Idkey is the unique identifier, allowing the item to be easily re-imported.",
             "examples": [
-              ""
+              "10784",
+              "10753",
+              "10780",
+              "10776",
+              "10777",
+              "10781",
+              "10775",
+              "10752",
+              "10782",
+              "10798",
+              "10778",
+              "13357",
+              "13175",
+              "10779",
+              "10783",
+              "13174"
             ]
           },
-          "name": {
+          "Name": {
             "type": "string",
-            "title": "The name Schema",
+            "title": "The Name Schema",
             "examples": [
-              "Administration",
-              "Brawling"
+              "Area Knowledge (local)",
+              "Brawling",
+              "Carousing",
+              "Connoisseur (Music)",
+              "Dancing",
+              "Forced Entry",
+              "Guns (Pistol)",
+              "Innate Attack (Projectile)",
+              "Intimidation",
+              "Leadership",
+              "Musical Instrument (Guitar)",
+              "Navigation (Land)",
+              "Shield (Force)",
+              "Singing",
+              "Streetwise",
+              "Wrestling"
             ]
           },
-          "tl": {
+          "Tl": {
             "type": "string",
-            "title": "The tl Schema",
+            "title": "The Tl Schema",
             "examples": [
-              ""
+              "",
+              "8"
             ]
           },
-          "base": {
+          "Base": {
             "type": "string",
-            "title": "The base Schema",
+            "title": "The Base Schema",
             "examples": [
-              "IQ",
-              "DX"
+              "@{intelligence}",
+              "@{dexterity}",
+              "@{health}",
+              "10"
             ]
           },
-          "difficulty": {
+          "Difficulty": {
             "type": "string",
-            "title": "The difficulty Schema",
+            "title": "The Difficulty Schema",
             "examples": [
+              "E",
               "A",
-              "E"
+              "H"
             ]
           },
-          "bonus": {
-            "type": "integer",
-            "title": "The bonus Schema",
+          "Bonus": {
+            "type": "number",
+            "title": "The Bonus Schema",
             "examples": [
-              0
+              0.0,
+              1.0,
+              2.0
             ]
           },
-          "points": {
-            "type": "integer",
-            "title": "The points Schema",
+          "Points": {
+            "type": "number",
+            "title": "The Points Schema",
             "examples": [
-              1,
-              4
+              2.0,
+              4.0,
+              3.0,
+              1.0,
+              12.0,
+              8.0
             ]
           },
-          "skill": {
-            "type": "integer",
-            "title": "The skill Schema",
+          "Skill": {
+            "type": "number",
+            "title": "The Skill Schema",
             "examples": [
-              15,
-              14
+              11.0,
+              14.0,
+              13.0,
+              17.0,
+              12.0,
+              10.0
             ]
           },
-          "use_wildcard_points": {
-            "type": "integer",
-            "default": 0,
-            "title": "The use_wildcard_points Schema",
-            "examples": [
-              0
-            ]
-          },
-          "use_normal_points": {
-            "type": "integer",
-            "default": 0,
-            "title": "The use_normal_points Schema",
-            "examples": [
-              1
-            ]
-          },
-          "wildcard_skill_points": {
-            "type": "integer",
-            "default": 0,
-            "title": "The wildcard_skill_points Schema",
-            "examples": [
-              1
-            ]
-          },
-          "ref": {
+          "Ref": {
             "type": "string",
-            "title": "The ref Schema",
+            "title": "The Ref Schema",
             "examples": [
-              "B174"
+              "B176",
+              "B182",
+              "B183",
+              "B185",
+              "B187",
+              "B196",
+              "B198",
+              "B201",
+              "B202",
+              "B204",
+              "B211",
+              "B220",
+              "B223",
+              "B228"
             ]
           },
-          "skill_mod_notes": {
+          "SkillModNotes": {
             "type": "string",
-            "title": "The skill_mod_notes Schema",
+            "title": "The SkillModNotes Schema",
             "examples": [
-              ""
+              "",
+              "+1 from 'Body Control Talent 1 (Innate Attack (Projectile), +0)'",
+              "+2 from 'Charisma 2'"
             ]
           },
-          "notes": {
+          "Notes": {
             "type": "string",
-            "title": "The notes Schema",
+            "title": "The Notes Schema",
             "examples": [
-              ""
+              "local",
+              "Notes: Calculated damage takes into account bonuses from Teeth, Weak Bite, Claws, and skill level. You may add the modifier \"Has Gauntlets/Brass Knuckles\" or \"Has Boots\" to apply the +1 damage to Punch or Kick, as appropriate.",
+              "",
+              "Music",
+              "uns/TL8 (Pistol",
+              "Projectile",
+              "Guitar",
+              "avigation/TL8 (Land",
+              "Force"
             ]
           }
         },
         "examples": [
           {
-            "idkey": "",
-            "name": "Administration",
-            "tl": "",
-            "base": "IQ",
-            "difficulty": "A",
-            "bonus": 0,
-            "points": 1,
-            "use_wildcard_points": 0,
-            "use_normal_points": 1,
-            "wildcard_skill_points": 1,
-            "ref": "B174",
-            "skill_mod_notes": "",
-            "notes": ""
+            "Idkey": "10784",
+            "Name": "Area Knowledge (local)",
+            "Tl": "",
+            "Base": "@{intelligence}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 2.0,
+            "Skill": 11.0,
+            "Ref": "B176",
+            "SkillModNotes": "",
+            "Notes": "local"
           },
           {
-            "idkey": "",
-            "name": "Brawling",
-            "tl": "",
-            "base": "DX",
-            "difficulty": "E",
-            "bonus": 0,
-            "points": 4,
-            "ref": "B174",
-            "skill_mod_notes": "",
-            "notes": ""
+            "Idkey": "10753",
+            "Name": "Brawling",
+            "Tl": "",
+            "Base": "@{dexterity}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 4.0,
+            "Skill": 14.0,
+            "Ref": "B182",
+            "SkillModNotes": "",
+            "Notes": "Notes: Calculated damage takes into account bonuses from Teeth, Weak Bite, Claws, and skill level. You may add the modifier \"Has Gauntlets/Brass Knuckles\" or \"Has Boots\" to apply the +1 damage to Punch or Kick, as appropriate."
+          },
+          {
+            "Idkey": "10780",
+            "Name": "Carousing",
+            "Tl": "",
+            "Base": "@{health}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 2.0,
+            "Skill": 13.0,
+            "Ref": "B183",
+            "SkillModNotes": "",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10776",
+            "Name": "Connoisseur (Music)",
+            "Tl": "",
+            "Base": "@{intelligence}",
+            "Difficulty": "A",
+            "Bonus": 0.0,
+            "Points": 3.0,
+            "Skill": 11.0,
+            "Ref": "B185",
+            "SkillModNotes": "",
+            "Notes": "Music"
+          },
+          {
+            "Idkey": "10777",
+            "Name": "Dancing",
+            "Tl": "",
+            "Base": "@{dexterity}",
+            "Difficulty": "A",
+            "Bonus": 0.0,
+            "Points": 1.0,
+            "Skill": 11.0,
+            "Ref": "B187",
+            "SkillModNotes": "",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10781",
+            "Name": "Forced Entry",
+            "Tl": "",
+            "Base": "@{dexterity}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 2.0,
+            "Skill": 13.0,
+            "Ref": "B196",
+            "SkillModNotes": "",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10775",
+            "Name": "Guns (Pistol)",
+            "Tl": "8",
+            "Base": "@{dexterity}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 4.0,
+            "Skill": 14.0,
+            "Ref": "B198",
+            "SkillModNotes": "",
+            "Notes": "uns/TL8 (Pistol"
+          },
+          {
+            "Idkey": "10752",
+            "Name": "Innate Attack (Projectile)",
+            "Tl": "",
+            "Base": "@{dexterity}",
+            "Difficulty": "E",
+            "Bonus": 1.0,
+            "Points": 12.0,
+            "Skill": 17.0,
+            "Ref": "B201",
+            "SkillModNotes": "+1 from 'Body Control Talent 1 (Innate Attack (Projectile), +0)'",
+            "Notes": "Projectile"
+          },
+          {
+            "Idkey": "10782",
+            "Name": "Intimidation",
+            "Tl": "",
+            "Base": "10",
+            "Difficulty": "A",
+            "Bonus": 0.0,
+            "Points": 4.0,
+            "Skill": 13.0,
+            "Ref": "B202",
+            "SkillModNotes": "",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10798",
+            "Name": "Leadership",
+            "Tl": "",
+            "Base": "@{intelligence}",
+            "Difficulty": "A",
+            "Bonus": 2.0,
+            "Points": 4.0,
+            "Skill": 13.0,
+            "Ref": "B204",
+            "SkillModNotes": "+2 from 'Charisma 2'",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10778",
+            "Name": "Musical Instrument (Guitar)",
+            "Tl": "",
+            "Base": "@{intelligence}",
+            "Difficulty": "H",
+            "Bonus": 0.0,
+            "Points": 12.0,
+            "Skill": 12.0,
+            "Ref": "B211",
+            "SkillModNotes": "",
+            "Notes": "Guitar"
+          },
+          {
+            "Idkey": "13357",
+            "Name": "Navigation (Land)",
+            "Tl": "8",
+            "Base": "@{intelligence}",
+            "Difficulty": "A",
+            "Bonus": 0.0,
+            "Points": 2.0,
+            "Skill": 10.0,
+            "Ref": "B211",
+            "SkillModNotes": "",
+            "Notes": "avigation/TL8 (Land"
+          },
+          {
+            "Idkey": "13175",
+            "Name": "Shield (Force)",
+            "Tl": "",
+            "Base": "@{dexterity}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 2.0,
+            "Skill": 13.0,
+            "Ref": "B220",
+            "SkillModNotes": "",
+            "Notes": "Force"
+          },
+          {
+            "Idkey": "10779",
+            "Name": "Singing",
+            "Tl": "",
+            "Base": "@{health}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 2.0,
+            "Skill": 13.0,
+            "Ref": "B220",
+            "SkillModNotes": "",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10783",
+            "Name": "Streetwise",
+            "Tl": "",
+            "Base": "@{intelligence}",
+            "Difficulty": "A",
+            "Bonus": 0.0,
+            "Points": 8.0,
+            "Skill": 12.0,
+            "Ref": "B223",
+            "SkillModNotes": "",
+            "Notes": ""
+          },
+          {
+            "Idkey": "13174",
+            "Name": "Wrestling",
+            "Tl": "",
+            "Base": "@{dexterity}",
+            "Difficulty": "A",
+            "Bonus": 0.0,
+            "Points": 1.0,
+            "Skill": 11.0,
+            "Ref": "B228",
+            "SkillModNotes": "",
+            "Notes": ""
           }
         ]
       },
       "examples": [
         [
           {
-            "idkey": "",
-            "name": "Administration",
-            "tl": "",
-            "base": "IQ",
-            "difficulty": "A",
-            "bonus": 0,
-            "points": 1,
-            "use_wildcard_points": 0,
-            "use_normal_points": 1,
-            "wildcard_skill_points": 1,
-            "ref": "B174",
-            "skill_mod_notes": "",
-            "notes": ""
+            "Idkey": "10784",
+            "Name": "Area Knowledge (local)",
+            "Tl": "",
+            "Base": "@{intelligence}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 2.0,
+            "Skill": 11.0,
+            "Ref": "B176",
+            "SkillModNotes": "",
+            "Notes": "local"
           },
           {
-            "idkey": "",
-            "name": "Brawling",
-            "tl": "",
-            "base": "DX",
-            "difficulty": "E",
-            "bonus": 0,
-            "points": 4,
-            "ref": "B174",
-            "skill_mod_notes": "",
-            "notes": ""
+            "Idkey": "10753",
+            "Name": "Brawling",
+            "Tl": "",
+            "Base": "@{dexterity}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 4.0,
+            "Skill": 14.0,
+            "Ref": "B182",
+            "SkillModNotes": "",
+            "Notes": "Notes: Calculated damage takes into account bonuses from Teeth, Weak Bite, Claws, and skill level. You may add the modifier \"Has Gauntlets/Brass Knuckles\" or \"Has Boots\" to apply the +1 damage to Punch or Kick, as appropriate."
+          },
+          {
+            "Idkey": "10780",
+            "Name": "Carousing",
+            "Tl": "",
+            "Base": "@{health}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 2.0,
+            "Skill": 13.0,
+            "Ref": "B183",
+            "SkillModNotes": "",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10776",
+            "Name": "Connoisseur (Music)",
+            "Tl": "",
+            "Base": "@{intelligence}",
+            "Difficulty": "A",
+            "Bonus": 0.0,
+            "Points": 3.0,
+            "Skill": 11.0,
+            "Ref": "B185",
+            "SkillModNotes": "",
+            "Notes": "Music"
+          },
+          {
+            "Idkey": "10777",
+            "Name": "Dancing",
+            "Tl": "",
+            "Base": "@{dexterity}",
+            "Difficulty": "A",
+            "Bonus": 0.0,
+            "Points": 1.0,
+            "Skill": 11.0,
+            "Ref": "B187",
+            "SkillModNotes": "",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10781",
+            "Name": "Forced Entry",
+            "Tl": "",
+            "Base": "@{dexterity}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 2.0,
+            "Skill": 13.0,
+            "Ref": "B196",
+            "SkillModNotes": "",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10775",
+            "Name": "Guns (Pistol)",
+            "Tl": "8",
+            "Base": "@{dexterity}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 4.0,
+            "Skill": 14.0,
+            "Ref": "B198",
+            "SkillModNotes": "",
+            "Notes": "uns/TL8 (Pistol"
+          },
+          {
+            "Idkey": "10752",
+            "Name": "Innate Attack (Projectile)",
+            "Tl": "",
+            "Base": "@{dexterity}",
+            "Difficulty": "E",
+            "Bonus": 1.0,
+            "Points": 12.0,
+            "Skill": 17.0,
+            "Ref": "B201",
+            "SkillModNotes": "+1 from 'Body Control Talent 1 (Innate Attack (Projectile), +0)'",
+            "Notes": "Projectile"
+          },
+          {
+            "Idkey": "10782",
+            "Name": "Intimidation",
+            "Tl": "",
+            "Base": "10",
+            "Difficulty": "A",
+            "Bonus": 0.0,
+            "Points": 4.0,
+            "Skill": 13.0,
+            "Ref": "B202",
+            "SkillModNotes": "",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10798",
+            "Name": "Leadership",
+            "Tl": "",
+            "Base": "@{intelligence}",
+            "Difficulty": "A",
+            "Bonus": 2.0,
+            "Points": 4.0,
+            "Skill": 13.0,
+            "Ref": "B204",
+            "SkillModNotes": "+2 from 'Charisma 2'",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10778",
+            "Name": "Musical Instrument (Guitar)",
+            "Tl": "",
+            "Base": "@{intelligence}",
+            "Difficulty": "H",
+            "Bonus": 0.0,
+            "Points": 12.0,
+            "Skill": 12.0,
+            "Ref": "B211",
+            "SkillModNotes": "",
+            "Notes": "Guitar"
+          },
+          {
+            "Idkey": "13357",
+            "Name": "Navigation (Land)",
+            "Tl": "8",
+            "Base": "@{intelligence}",
+            "Difficulty": "A",
+            "Bonus": 0.0,
+            "Points": 2.0,
+            "Skill": 10.0,
+            "Ref": "B211",
+            "SkillModNotes": "",
+            "Notes": "avigation/TL8 (Land"
+          },
+          {
+            "Idkey": "13175",
+            "Name": "Shield (Force)",
+            "Tl": "",
+            "Base": "@{dexterity}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 2.0,
+            "Skill": 13.0,
+            "Ref": "B220",
+            "SkillModNotes": "",
+            "Notes": "Force"
+          },
+          {
+            "Idkey": "10779",
+            "Name": "Singing",
+            "Tl": "",
+            "Base": "@{health}",
+            "Difficulty": "E",
+            "Bonus": 0.0,
+            "Points": 2.0,
+            "Skill": 13.0,
+            "Ref": "B220",
+            "SkillModNotes": "",
+            "Notes": ""
+          },
+          {
+            "Idkey": "10783",
+            "Name": "Streetwise",
+            "Tl": "",
+            "Base": "@{intelligence}",
+            "Difficulty": "A",
+            "Bonus": 0.0,
+            "Points": 8.0,
+            "Skill": 12.0,
+            "Ref": "B223",
+            "SkillModNotes": "",
+            "Notes": ""
+          },
+          {
+            "Idkey": "13174",
+            "Name": "Wrestling",
+            "Tl": "",
+            "Base": "@{dexterity}",
+            "Difficulty": "A",
+            "Bonus": 0.0,
+            "Points": 1.0,
+            "Skill": 11.0,
+            "Ref": "B228",
+            "SkillModNotes": "",
+            "Notes": ""
           }
         ]
       ]
     },
-    "repeating_techniquesrevised": {
+    "RepeatingTechniquesrevised": {
       "type": "array",
       "default": [],
-      "title": "The repeating_techniquesrevised Schema",
+      "title": "The RepeatingTechniquesrevised Schema",
       "items": {
         "type": "object",
-        "default": {},
         "title": "A Schema",
         "required": [
-          "idkey",
-          "name",
-          "parent",
-          "base_level",
-          "default",
-          "max_modifier",
-          "difficulty",
-          "skill_modifier",
-          "points",
-          "ref",
-          "skill_mod_notes",
-          "notes"
+          "Idkey",
+          "Name",
+          "Parent",
+          "BaseLevel",
+          "Default",
+          "MaxModifier",
+          "Difficulty",
+          "SkillModifier",
+          "Points",
+          "Skill",
+          "Ref",
+          "SkillModNotes",
+          "Notes"
         ],
         "properties": {
-          "idkey": {
+          "Idkey": {
             "type": "string",
-            "default": "",
-            "title": "The idkey Schema",
+            "title": "The Idkey is the unique identifier, allowing the item to be easily re-imported.",
+            "examples": [
+              "13172",
+              "13173"
+            ]
+          },
+          "Name": {
+            "type": "string",
+            "title": "The Name Schema",
+            "examples": [
+              "Aggressive Parry (Brawling)",
+              "Arm Lock (Wrestling)"
+            ]
+          },
+          "Parent": {
+            "type": "string",
+            "title": "The Parent Schema",
+            "examples": [
+              "Brawling",
+              "Wrestling"
+            ]
+          },
+          "BaseLevel": {
+            "type": "string",
+            "title": "The BaseLevel Schema",
+            "examples": [
+              "10",
+              "11"
+            ]
+          },
+          "Default": {
+            "type": "number",
+            "title": "The Default Schema",
+            "examples": [
+              "-",
+              1.0,
+              0.0
+            ]
+          },
+          "MaxModifier": {
+            "type": "number",
+            "title": "The MaxModifier Schema",
+            "examples": [
+              0.0,
+              4.0
+            ]
+          },
+          "Difficulty": {
+            "type": "string",
+            "title": "The Difficulty Schema",
+            "examples": [
+              "H",
+              "A"
+            ]
+          },
+          "SkillModifier": {
+            "type": "number",
+            "title": "The SkillModifier Schema",
+            "examples": [
+              0.0
+            ]
+          },
+          "Points": {
+            "type": "number",
+            "title": "The Points Schema",
+            "examples": [
+              2.0
+            ]
+          },
+          "Skill": {
+            "type": "number",
+            "title": "The Skill Schema",
+            "examples": [
+              11.0,
+              13.0
+            ]
+          },
+          "Ref": {
+            "type": "string",
+            "title": "The Ref Schema",
+            "examples": [
+              "MA65",
+              "MA65, B230"
+            ]
+          },
+          "SkillModNotes": {
+            "type": "string",
+            "title": "The SkillModNotes Schema",
             "examples": [
               ""
             ]
           },
-          "name": {
+          "Notes": {
             "type": "string",
-            "default": "",
-            "title": "The name Schema",
+            "title": "The Notes Schema",
             "examples": [
-              "Elbow Punch"
-            ]
-          },
-          "parent": {
-            "type": "string",
-            "default": "",
-            "title": "The parent Schema",
-            "examples": [
-              "Brawling"
-            ]
-          },
-          "base_level": {
-            "type": "integer",
-            "default": 0,
-            "title": "The base_level Schema",
-            "examples": [
-              14
-            ]
-          },
-          "default": {
-            "type": "integer",
-            "default": 0,
-            "title": "The default Schema",
-            "examples": [
-              "-2"
-            ]
-          },
-          "max_modifier": {
-            "type": "integer",
-            "default": 0,
-            "title": "The max_modifier Schema",
-            "examples": [
-              2
-            ]
-          },
-          "difficulty": {
-            "type": "string",
-            "default": "",
-            "title": "The difficulty Schema",
-            "examples": [
-              "Hard"
-            ]
-          },
-          "skill_modifier": {
-            "type": "integer",
-            "default": 0,
-            "title": "The skill_modifier Schema",
-            "examples": [
-              0
-            ]
-          },
-          "points": {
-            "type": "integer",
-            "default": 0,
-            "title": "The points Schema",
-            "examples": [
-              2
-            ]
-          },
-          "ref": {
-            "type": "string",
-            "default": "",
-            "title": "The ref Schema",
-            "examples": [
-              ""
-            ]
-          },
-          "skill_mod_notes": {
-            "type": "string",
-            "default": "",
-            "title": "The skill_mod_notes Schema",
-            "examples": [
-              ""
-            ]
-          },
-          "notes": {
-            "type": "string",
-            "default": "",
-            "title": "The notes Schema",
-            "examples": [
-              ""
+              "Brawling",
+              "Wrestling"
             ]
           }
         },
         "examples": [
           {
-            "idkey": "",
-            "name": "Elbow Punch",
-            "parent": "Brawling",
-            "base_level": 14,
-            "default": "-2",
-            "max_modifier": 2,
-            "difficulty": "Hard",
-            "skill_modifier": 0,
-            "points": 2,
-            "ref": "",
-            "skill_mod_notes": "",
-            "notes": ""
+            "Idkey": "13172",
+            "Name": "Aggressive Parry (Brawling)",
+            "Parent": "Brawling",
+            "BaseLevel": "10",
+            "Default": "-",
+            1.0,
+            "MaxModifier": 0.0,
+            "Difficulty": "H",
+            "SkillModifier": 0.0,
+            "Points": 2.0,
+            "Skill": 11.0,
+            "Ref": "MA65",
+            "SkillModNotes": "",
+            "Notes": "Brawling"
+          },
+          {
+            "Idkey": "13173",
+            "Name": "Arm Lock (Wrestling)",
+            "Parent": "Wrestling",
+            "BaseLevel": "11",
+            "Default": 0.0,
+            "MaxModifier": 4.0,
+            "Difficulty": "A",
+            "SkillModifier": 0.0,
+            "Points": 2.0,
+            "Skill": 13.0,
+            "Ref": "MA65, B230",
+            "SkillModNotes": "",
+            "Notes": "Wrestling"
           }
         ]
       },
       "examples": [
         [
           {
-            "idkey": "",
-            "name": "Elbow Punch",
-            "parent": "Brawling",
-            "base_level": 14,
-            "default": "-2",
-            "max_modifier": 2,
-            "difficulty": "Hard",
-            "skill_modifier": 0,
-            "points": 2,
-            "ref": "",
-            "skill_mod_notes": "",
-            "notes": ""
+            "Idkey": "13172",
+            "Name": "Aggressive Parry (Brawling)",
+            "Parent": "Brawling",
+            "BaseLevel": "10",
+            "Default": "-",
+            1.0,
+            "MaxModifier": 0.0,
+            "Difficulty": "H",
+            "SkillModifier": 0.0,
+            "Points": 2.0,
+            "Skill": 11.0,
+            "Ref": "MA65",
+            "SkillModNotes": "",
+            "Notes": "Brawling"
+          },
+          {
+            "Idkey": "13173",
+            "Name": "Arm Lock (Wrestling)",
+            "Parent": "Wrestling",
+            "BaseLevel": "11",
+            "Default": 0.0,
+            "MaxModifier": 4.0,
+            "Difficulty": "A",
+            "SkillModifier": 0.0,
+            "Points": 2.0,
+            "Skill": 13.0,
+            "Ref": "MA65, B230",
+            "SkillModNotes": "",
+            "Notes": "Wrestling"
           }
         ]
       ]
     },
-    "repeating_defense": {
+    "RepeatingDefense": {
       "type": "array",
       "default": [],
-      "title": "The repeating_defense Schema",
+      "title": "The RepeatingDefense Schema",
       "items": {
         "type": "object",
         "title": "A Schema",
         "required": [
-          "idkey",
-          "name",
-          "type",
-          "info",
-          "skill",
-          "skill_mod",
-          "defense_mod_reason",
-          "info_description"
+          "Idkey",
+          "Name",
+          "Type",
+          "Info",
+          "Skill",
+          "SkillMod",
+          "DefenseModReason",
+          "InfoDescription"
         ],
         "properties": {
-          "idkey": {
+          "Idkey": {
             "type": "string",
-            "title": "The idkey Schema",
+            "title": "The Idkey is the unique identifier, allowing the item to be easily re-imported.",
             "examples": [
-              ""
+              "10704_power_dodge",
+              "10704_power_block",
+              "10704_power_block_mental",
+              "10753_unarmed_parry",
+              "10613_unarmed_parry",
+              "13175_block"
             ]
           },
-          "name": {
+          "Name": {
             "type": "string",
-            "title": "The name Schema",
+            "title": "The Name Schema",
             "examples": [
+              "Body Control Talent (Power Dodge)",
+              "Body Control Talent (Power Block/Physical)",
+              "Body Control Talent (Power Block/Mental)",
+              "Brawling (Punch)",
               "Punch",
-              "Brawling (Punch)"
+              "Shield (Force)"
             ]
           },
-          "type": {
+          "Type": {
             "type": "string",
-            "title": "The type Schema",
+            "title": "The Type Schema",
             "examples": [
-              "Unarmed Parry"
+              "Power Dodge",
+              "Power Block",
+              "Power Block Mental",
+              "Unarmed Parry",
+              "Block"
             ]
           },
-          "info": {
+          "Info": {
             "type": "string",
-            "title": "The info Schema",
+            "title": "The Info Schema",
             "examples": [
               ""
             ]
           },
-          "skill": {
-            "type": "integer",
-            "title": "The skill Schema",
+          "Skill": {
+            "type": "number",
+            "title": "The Skill Schema",
             "examples": [
-              10
+              9.0,
+              11.0,
+              10.0
             ]
           },
-          "skill_mod": {
-            "type": "integer",
-            "title": "The skill_mod Schema",
+          "SkillMod": {
+            "type": "number",
+            "title": "The SkillMod Schema",
             "examples": [
-              0
+              0.0
             ]
           },
-          "defense_mod_reason": {
+          "DefenseModReason": {
             "type": "string",
-            "title": "The defense_mod_reason Schema",
+            "title": "The DefenseModReason Schema",
             "examples": [
               ""
             ]
           },
-          "info_description": {
+          "InfoDescription": {
             "type": "string",
-            "title": "The info_description Schema",
+            "title": "The InfoDescription Schema",
             "examples": [
               ""
             ]
@@ -1977,335 +2858,574 @@
         },
         "examples": [
           {
-            "idkey": "",
-            "name": "Punch",
-            "type": "Unarmed Parry",
-            "info": "",
-            "skill": 10,
-            "skill_mod": 0,
-            "defense_mod_reason": "",
-            "info_description": ""
+            "Idkey": "10704_power_dodge",
+            "Name": "Body Control Talent (Power Dodge)",
+            "Type": "Power Dodge",
+            "Info": "",
+            "Skill": 9.0,
+            "SkillMod": 0.0,
+            "DefenseModReason": "",
+            "InfoDescription": ""
           },
           {
-            "idkey": "",
-            "name": "Brawling (Punch)",
-            "type": "Unarmed Parry",
-            "info": "",
-            "skill": 10,
-            "skill_mod": 0,
-            "defense_mod_reason": "",
-            "info_description": ""
+            "Idkey": "10704_power_block",
+            "Name": "Body Control Talent (Power Block/Physical)",
+            "Type": "Power Block",
+            "Info": "",
+            "Skill": 9.0,
+            "SkillMod": 0.0,
+            "DefenseModReason": "",
+            "InfoDescription": ""
+          },
+          {
+            "Idkey": "10704_power_block_mental",
+            "Name": "Body Control Talent (Power Block/Mental)",
+            "Type": "Power Block Mental",
+            "Info": "",
+            "Skill": 9.0,
+            "SkillMod": 0.0,
+            "DefenseModReason": "",
+            "InfoDescription": ""
+          },
+          {
+            "Idkey": "10753_unarmed_parry",
+            "Name": "Brawling (Punch)",
+            "Type": "Unarmed Parry",
+            "Info": "",
+            "Skill": 11.0,
+            "SkillMod": 0.0,
+            "DefenseModReason": "",
+            "InfoDescription": ""
+          },
+          {
+            "Idkey": "10613_unarmed_parry",
+            "Name": "Punch",
+            "Type": "Unarmed Parry",
+            "Info": "",
+            "Skill": 11.0,
+            "SkillMod": 0.0,
+            "DefenseModReason": "",
+            "InfoDescription": ""
+          },
+          {
+            "Idkey": "13175_block",
+            "Name": "Shield (Force)",
+            "Type": "Block",
+            "Info": "",
+            "Skill": 10.0,
+            "SkillMod": 0.0,
+            "DefenseModReason": "",
+            "InfoDescription": ""
           }
         ]
       },
       "examples": [
         [
           {
-            "idkey": "",
-            "name": "Punch",
-            "type": "Unarmed Parry",
-            "info": "",
-            "skill": 10,
-            "skill_mod": 0,
-            "defense_mod_reason": "",
-            "info_description": ""
+            "Idkey": "10704_power_dodge",
+            "Name": "Body Control Talent (Power Dodge)",
+            "Type": "Power Dodge",
+            "Info": "",
+            "Skill": 9.0,
+            "SkillMod": 0.0,
+            "DefenseModReason": "",
+            "InfoDescription": ""
           },
           {
-            "idkey": "",
-            "name": "Brawling (Punch)",
-            "type": "Unarmed Parry",
-            "info": "",
-            "skill": 10,
-            "skill_mod": 0,
-            "defense_mod_reason": "",
-            "info_description": ""
+            "Idkey": "10704_power_block",
+            "Name": "Body Control Talent (Power Block/Physical)",
+            "Type": "Power Block",
+            "Info": "",
+            "Skill": 9.0,
+            "SkillMod": 0.0,
+            "DefenseModReason": "",
+            "InfoDescription": ""
+          },
+          {
+            "Idkey": "10704_power_block_mental",
+            "Name": "Body Control Talent (Power Block/Mental)",
+            "Type": "Power Block Mental",
+            "Info": "",
+            "Skill": 9.0,
+            "SkillMod": 0.0,
+            "DefenseModReason": "",
+            "InfoDescription": ""
+          },
+          {
+            "Idkey": "10753_unarmed_parry",
+            "Name": "Brawling (Punch)",
+            "Type": "Unarmed Parry",
+            "Info": "",
+            "Skill": 11.0,
+            "SkillMod": 0.0,
+            "DefenseModReason": "",
+            "InfoDescription": ""
+          },
+          {
+            "Idkey": "10613_unarmed_parry",
+            "Name": "Punch",
+            "Type": "Unarmed Parry",
+            "Info": "",
+            "Skill": 11.0,
+            "SkillMod": 0.0,
+            "DefenseModReason": "",
+            "InfoDescription": ""
+          },
+          {
+            "Idkey": "13175_block",
+            "Name": "Shield (Force)",
+            "Type": "Block",
+            "Info": "",
+            "Skill": 10.0,
+            "SkillMod": 0.0,
+            "DefenseModReason": "",
+            "InfoDescription": ""
           }
         ]
       ]
     },
-    "repeating_melee": {
+    "RepeatingMelee": {
       "type": "array",
       "default": [],
-      "title": "The repeating_melee Schema",
+      "title": "The RepeatingMelee Schema",
       "items": {
         "type": "object",
-        "default": {},
         "title": "A Schema",
         "required": [
-          "idkey",
-          "name",
-          "damage",
-          "type",
-          "reach",
-          "skill",
-          "reason_for_mod",
-          "armor_divisor",
-          "notes"
+          "Idkey",
+          "Name",
+          "Damage",
+          "Type",
+          "Reach",
+          "Skill",
+          "ArmorDivisor",
+          "Notes"
         ],
         "properties": {
-          "idkey": {
+          "Idkey": {
             "type": "string",
-            "default": "",
-            "title": "The idkey Schema",
+            "title": "The Idkey is the unique identifier, allowing the item to be easily re-imported.",
             "examples": [
-              "13"
+              "13172_aggressiveparry_",
+              "10525_bite_bite",
+              "10753_brawling_punch",
+              "10753_brawling_bite",
+              "10753_brawling_kick",
+              "13176_forceshield_bash",
+              "13176_forceshield_rush",
+              "10558_kick_kick",
+              "10613_punch_punch"
             ]
           },
-          "name": {
+          "Name": {
             "type": "string",
-            "default": "",
-            "title": "The name Schema",
+            "title": "The Name Schema",
             "examples": [
-              "Bite"
+              "Aggressive Parry (Brawling)",
+              "Bite",
+              "Brawling (Punch)",
+              "Brawling (Bite)",
+              "Brawling (Kick)",
+              "Force Shield (Bash)",
+              "Force Shield (Rush)",
+              "Kick",
+              "Punch"
             ]
           },
-          "damage": {
+          "Damage": {
             "type": "string",
-            "default": "",
-            "title": "The damage Schema",
+            "title": "The Damage Schema",
             "examples": [
-              "1d6-1"
+              "2d6-2",
+              "2d6+1",
+              "2d6+2",
+              "2d6",
+              "slam+3"
             ]
           },
-          "type": {
+          "Type": {
             "type": "string",
-            "default": "",
-            "title": "The type Schema",
+            "title": "The Type Schema",
             "examples": [
               "cr"
             ]
           },
-          "reach": {
+          "Reach": {
             "type": "string",
-            "default": "",
-            "title": "The reach Schema",
+            "title": "The Reach Schema",
             "examples": [
-              "c"
+              "C",
+              "C,1",
+              "1"
             ]
           },
-          "skill": {
-            "type": "integer",
-            "default": 0,
-            "title": "The skill Schema",
+          "Skill": {
+            "type": "number",
+            "title": "The Skill Schema",
             "examples": [
-              14
+              11.0,
+              14.0,
+              12.0,
+              13.0
             ]
           },
-          "reason_for_mod": {
+          "ArmorDivisor": {
+            "type": "number",
+            "title": "The ArmorDivisor Schema",
+            "examples": [
+              1.0
+            ]
+          },
+          "Notes": {
             "type": "string",
-            "default": "",
-            "title": "The reason_for_mod Schema",
+            "title": "The Notes Schema",
             "examples": [
-              ""
-            ]
-          },
-          "armor_divisor": {
-            "type": "integer",
-            "default": 0,
-            "title": "The armor_divisor Schema",
-            "examples": [
-              1
-            ]
-          },
-          "notes": {
-            "type": "string",
-            "default": "",
-            "title": "The notes Schema",
-            "examples": [
-              ""
+              "",
+              "{Brawling (p. B182) increases all unarmed damage; Claws (p. B42) and Karate (p. B203) improve damage with punches and kicks (Claws don't affect damage with brass knuckles or boots); and Boxing (p. B182) improves punching damage.}",
+              "{If you miss with a kick, roll vs. DX to avoid falling.}",
+              "{Worn on the wrist, leaving the hand free.}"
             ]
           }
         },
         "examples": [
           {
-            "idkey": "13",
-            "name": "Bite",
-            "damage": "1d6-1",
-            "type": "cr",
-            "reach": "c",
-            "skill": 14,
-            "reason_for_mod": "",
-            "armor_divisor": 1,
-            "notes": ""
+            "Idkey": "13172_aggressiveparry_",
+            "Name": "Aggressive Parry (Brawling)",
+            "Damage": "2d6-2",
+            "Type": "cr",
+            "Reach": "C",
+            "Skill": 11.0,
+            "ArmorDivisor": 1.0,
+            "Notes": ""
+          },
+          {
+            "Idkey": "10525_bite_bite",
+            "Name": "Bite",
+            "Damage": "2d6+1",
+            "Type": "cr",
+            "Reach": "C",
+            "Skill": 14.0,
+            "ArmorDivisor": 1.0,
+            "Notes": "{Brawling (p. B182) increases all unarmed damage; Claws (p. B42) and Karate (p. B203) improve damage with punches and kicks (Claws don't affect damage with brass knuckles or boots); and Boxing (p. B182) improves punching damage.}"
+          },
+          {
+            "Idkey": "10753_brawling_punch",
+            "Name": "Brawling (Punch)",
+            "Damage": "2d6+1",
+            "Type": "cr",
+            "Reach": "C",
+            "Skill": 14.0,
+            "ArmorDivisor": 1.0,
+            "Notes": ""
+          },
+          {
+            "Idkey": "10753_brawling_bite",
+            "Name": "Brawling (Bite)",
+            "Damage": "2d6+1",
+            "Type": "cr",
+            "Reach": "C",
+            "Skill": 14.0,
+            "ArmorDivisor": 1.0,
+            "Notes": ""
+          },
+          {
+            "Idkey": "10753_brawling_kick",
+            "Name": "Brawling (Kick)",
+            "Damage": "2d6+2",
+            "Type": "cr",
+            "Reach": "C,1",
+            "Skill": 12.0,
+            "ArmorDivisor": 1.0,
+            "Notes": "{If you miss with a kick, roll vs. DX to avoid falling.}"
+          },
+          {
+            "Idkey": "13176_forceshield_bash",
+            "Name": "Force Shield (Bash)",
+            "Damage": "2d6",
+            "Type": "cr",
+            "Reach": "1",
+            "Skill": 13.0,
+            "ArmorDivisor": 1.0,
+            "Notes": "{Worn on the wrist, leaving the hand free.}"
+          },
+          {
+            "Idkey": "13176_forceshield_rush",
+            "Name": "Force Shield (Rush)",
+            "Damage": "slam+3",
+            "Type": "cr",
+            "Reach": "1",
+            "Skill": 13.0,
+            "ArmorDivisor": 1.0,
+            "Notes": "{Worn on the wrist, leaving the hand free.}"
+          },
+          {
+            "Idkey": "10558_kick_kick",
+            "Name": "Kick",
+            "Damage": "2d6+2",
+            "Type": "cr",
+            "Reach": "C,1",
+            "Skill": 12.0,
+            "ArmorDivisor": 1.0,
+            "Notes": "{Brawling (p. B182) increases all unarmed damage; Claws (p. B42) and Karate (p. B203) improve damage with punches and kicks (Claws don't affect damage with brass knuckles or boots); and Boxing (p. B182) improves punching damage.}"
+          },
+          {
+            "Idkey": "10613_punch_punch",
+            "Name": "Punch",
+            "Damage": "2d6+1",
+            "Type": "cr",
+            "Reach": "C",
+            "Skill": 14.0,
+            "ArmorDivisor": 1.0,
+            "Notes": "{Brawling (p. B182) increases all unarmed damage; Claws (p. B42) and Karate (p. B203) improve damage with punches and kicks (Claws don't affect damage with brass knuckles or boots); and Boxing (p. B182) improves punching damage.}"
           }
         ]
       },
       "examples": [
         [
           {
-            "idkey": "13",
-            "name": "Bite",
-            "damage": "1d6-1",
-            "type": "cr",
-            "reach": "c",
-            "skill": 14,
-            "reason_for_mod": "",
-            "armor_divisor": 1,
-            "notes": ""
+            "Idkey": "13172_aggressiveparry_",
+            "Name": "Aggressive Parry (Brawling)",
+            "Damage": "2d6-2",
+            "Type": "cr",
+            "Reach": "C",
+            "Skill": 11.0,
+            "ArmorDivisor": 1.0,
+            "Notes": ""
+          },
+          {
+            "Idkey": "10525_bite_bite",
+            "Name": "Bite",
+            "Damage": "2d6+1",
+            "Type": "cr",
+            "Reach": "C",
+            "Skill": 14.0,
+            "ArmorDivisor": 1.0,
+            "Notes": "{Brawling (p. B182) increases all unarmed damage; Claws (p. B42) and Karate (p. B203) improve damage with punches and kicks (Claws don't affect damage with brass knuckles or boots); and Boxing (p. B182) improves punching damage.}"
+          },
+          {
+            "Idkey": "10753_brawling_punch",
+            "Name": "Brawling (Punch)",
+            "Damage": "2d6+1",
+            "Type": "cr",
+            "Reach": "C",
+            "Skill": 14.0,
+            "ArmorDivisor": 1.0,
+            "Notes": ""
+          },
+          {
+            "Idkey": "10753_brawling_bite",
+            "Name": "Brawling (Bite)",
+            "Damage": "2d6+1",
+            "Type": "cr",
+            "Reach": "C",
+            "Skill": 14.0,
+            "ArmorDivisor": 1.0,
+            "Notes": ""
+          },
+          {
+            "Idkey": "10753_brawling_kick",
+            "Name": "Brawling (Kick)",
+            "Damage": "2d6+2",
+            "Type": "cr",
+            "Reach": "C,1",
+            "Skill": 12.0,
+            "ArmorDivisor": 1.0,
+            "Notes": "{If you miss with a kick, roll vs. DX to avoid falling.}"
+          },
+          {
+            "Idkey": "13176_forceshield_bash",
+            "Name": "Force Shield (Bash)",
+            "Damage": "2d6",
+            "Type": "cr",
+            "Reach": "1",
+            "Skill": 13.0,
+            "ArmorDivisor": 1.0,
+            "Notes": "{Worn on the wrist, leaving the hand free.}"
+          },
+          {
+            "Idkey": "13176_forceshield_rush",
+            "Name": "Force Shield (Rush)",
+            "Damage": "slam+3",
+            "Type": "cr",
+            "Reach": "1",
+            "Skill": 13.0,
+            "ArmorDivisor": 1.0,
+            "Notes": "{Worn on the wrist, leaving the hand free.}"
+          },
+          {
+            "Idkey": "10558_kick_kick",
+            "Name": "Kick",
+            "Damage": "2d6+2",
+            "Type": "cr",
+            "Reach": "C,1",
+            "Skill": 12.0,
+            "ArmorDivisor": 1.0,
+            "Notes": "{Brawling (p. B182) increases all unarmed damage; Claws (p. B42) and Karate (p. B203) improve damage with punches and kicks (Claws don't affect damage with brass knuckles or boots); and Boxing (p. B182) improves punching damage.}"
+          },
+          {
+            "Idkey": "10613_punch_punch",
+            "Name": "Punch",
+            "Damage": "2d6+1",
+            "Type": "cr",
+            "Reach": "C",
+            "Skill": 14.0,
+            "ArmorDivisor": 1.0,
+            "Notes": "{Brawling (p. B182) increases all unarmed damage; Claws (p. B42) and Karate (p. B203) improve damage with punches and kicks (Claws don't affect damage with brass knuckles or boots); and Boxing (p. B182) improves punching damage.}"
           }
         ]
       ]
     },
-    "repeating_ranged": {
+    "RepeatingRanged": {
       "type": "array",
       "default": [],
-      "title": "The repeating_ranged Schema",
+      "title": "The RepeatingRanged Schema",
       "items": {
         "type": "object",
-        "default": {},
         "title": "A Schema",
         "required": [
-          "idkey",
-          "name",
-          "damage",
-          "type",
-          "acc",
-          "range",
-          "rof",
-          "shots",
-          "bulk",
-          "recoil",
-          "skill",
-          "reason_for_mod",
-          "malfunction",
-          "malfunction_verify",
-          "malfunction_very_reliable",
-          "armor_divisor",
-          "notes"
+          "Idkey",
+          "Name",
+          "Damage",
+          "Type",
+          "Acc",
+          "Range",
+          "Rof",
+          "Shots",
+          "Bulk",
+          "Recoil",
+          "Skill",
+          "Malfunction",
+          "MalfunctionVerify",
+          "MalfunctionVeryReliable",
+          "ArmorDivisor",
+          "Notes"
         ],
         "properties": {
-          "idkey": {
+          "Idkey": {
             "type": "string",
-            "default": "",
-            "title": "The idkey Schema",
+            "title": "The Idkey is the unique identifier, allowing the item to be easily re-imported.",
             "examples": [
-              ""
+              "10720_crossbow_primary",
+              "10730_crossbow_primary",
+              "10786_revolver357m_"
             ]
           },
-          "name": {
+          "Name": {
             "type": "string",
-            "default": "",
-            "title": "The name Schema",
+            "title": "The Name Schema",
             "examples": [
-              "Holdout Pistol, 7.5mmCLP"
+              "Crossbow (Armor Piercing) (Primary)",
+              "Crossbow (Explosive) (Primary)",
+              "Revolver, .357M"
             ]
           },
-          "damage": {
+          "Damage": {
             "type": "string",
-            "default": "",
-            "title": "The damage Schema",
+            "title": "The Damage Schema",
             "examples": [
-              "2d6"
+              "3d6",
+              "3d6-1"
             ]
           },
-          "type": {
+          "Type": {
             "type": "string",
-            "default": "",
-            "title": "The type Schema",
+            "title": "The Type Schema",
             "examples": [
+              "imp",
+              "cr dkb ex/2",
               "pi"
             ]
           },
-          "acc": {
+          "Acc": {
             "type": "string",
-            "default": "",
-            "title": "The acc Schema",
-            "examples": [
-              "1"
-            ]
-          },
-          "range": {
-            "type": "string",
-            "default": "",
-            "title": "The range Schema",
-            "examples": [
-              "100/1200"
-            ]
-          },
-          "rof": {
-            "type": "string",
-            "default": "",
-            "title": "The rof Schema",
-            "examples": [
-              "3"
-            ]
-          },
-          "shots": {
-            "type": "string",
-            "default": "",
-            "title": "The shots Schema",
-            "examples": [
-              "18+1(3)/0.2"
-            ]
-          },
-          "bulk": {
-            "type": "string",
-            "default": "",
-            "title": "The bulk Schema",
-            "examples": [
-              "-1"
-            ]
-          },
-          "recoil": {
-            "type": "string",
-            "default": "",
-            "title": "The recoil Schema",
+            "title": "The Acc Schema",
             "examples": [
               "2"
             ]
           },
-          "skill": {
-            "type": "integer",
-            "default": 0,
-            "title": "The skill Schema",
+          "Range": {
+            "type": "string",
+            "title": "The Range Schema",
             "examples": [
-              15
+              "100/200",
+              "200",
+              "185/2000"
             ]
           },
-          "reason_for_mod": {
+          "Rof": {
             "type": "string",
-            "default": "",
-            "title": "The reason_for_mod Schema",
+            "title": "The Rof Schema",
             "examples": [
-              ""
+              "1",
+              "3"
             ]
           },
-          "malfunction": {
+          "Shots": {
             "type": "string",
-            "default": "",
-            "title": "The malfunction Schema",
+            "title": "The Shots Schema",
             "examples": [
+              "",
+              "n/a",
+              "6(3i)"
+            ]
+          },
+          "Bulk": {
+            "type": "string",
+            "title": "The Bulk Schema",
+            "examples": [
+              "",
+              "-2"
+            ]
+          },
+          "Recoil": {
+            "type": "string",
+            "title": "The Recoil Schema",
+            "examples": [
+              "1",
+              "3"
+            ]
+          },
+          "Skill": {
+            "type": "number",
+            "title": "The Skill Schema",
+            "examples": [
+              17.0,
+              15.0
+            ]
+          },
+          "Malfunction": {
+            "type": "string",
+            "title": "The Malfunction Schema",
+            "examples": [
+              "",
               "17"
             ]
           },
-          "malfunction_verify": {
+          "MalfunctionVerify": {
             "type": "boolean",
-            "default": false,
-            "title": "The malfunction_verify Schema",
+            "title": "The MalfunctionVerify Schema",
             "examples": [
-              true
+              false
             ]
           },
-          "malfunction_very_reliable": {
+          "MalfunctionVeryReliable": {
             "type": "boolean",
-            "default": false,
-            "title": "The malfunction_very_reliable Schema",
+            "title": "The MalfunctionVeryReliable Schema",
             "examples": [
-              true
+              false
             ]
           },
-          "armor_divisor": {
+          "ArmorDivisor": {
             "type": "number",
-            "default": 0.0,
-            "title": "The armor_divisor Schema",
+            "title": "The ArmorDivisor Schema",
             "examples": [
-              0.5
+              2.0,
+              1.0
             ]
           },
-          "notes": {
+          "Notes": {
             "type": "string",
-            "default": "",
-            "title": "The notes Schema",
+            "title": "The Notes Schema",
             "examples": [
               ""
             ]
@@ -2313,921 +3433,1448 @@
         },
         "examples": [
           {
-            "idkey": "",
-            "name": "Holdout Pistol, 7.5mmCLP",
-            "damage": "2d6",
-            "type": "pi",
-            "acc": "1",
-            "range": "100/1200",
-            "rof": "3",
-            "shots": "18+1(3)/0.2",
-            "bulk": "-1",
-            "recoil": "2",
-            "skill": 15,
-            "reason_for_mod": "",
-            "malfunction": "17",
-            "malfunction_verify": true,
-            "malfunction_very_reliable": true,
-            "armor_divisor": 0.5,
-            "notes": ""
+            "Idkey": "10720_crossbow_primary",
+            "Name": "Crossbow (Armor Piercing) (Primary)",
+            "Damage": "3d6",
+            "Type": "imp",
+            "Acc": "2",
+            "Range": "100/200",
+            "Rof": "1",
+            "Shots": "",
+            "Bulk": "",
+            "Recoil": "1",
+            "Skill": 17.0,
+            "Malfunction": "",
+            "MalfunctionVerify": false,
+            "MalfunctionVeryReliable": false,
+            "ArmorDivisor": 2.0,
+            "Notes": ""
+          },
+          {
+            "Idkey": "10730_crossbow_primary",
+            "Name": "Crossbow (Explosive) (Primary)",
+            "Damage": "3d6",
+            "Type": "cr dkb ex/2",
+            "Acc": "2",
+            "Range": "200",
+            "Rof": "1",
+            "Shots": "n/a",
+            "Bulk": "",
+            "Recoil": "1",
+            "Skill": 17.0,
+            "Malfunction": "",
+            "MalfunctionVerify": false,
+            "MalfunctionVeryReliable": false,
+            "ArmorDivisor": 1.0,
+            "Notes": ""
+          },
+          {
+            "Idkey": "10786_revolver357m_",
+            "Name": "Revolver, .357M",
+            "Damage": "3d6-1",
+            "Type": "pi",
+            "Acc": "2",
+            "Range": "185/2000",
+            "Rof": "3",
+            "Shots": "6(3i)",
+            "Bulk": "-2",
+            "Recoil": "3",
+            "Skill": 15.0,
+            "Malfunction": "17",
+            "MalfunctionVerify": false,
+            "MalfunctionVeryReliable": false,
+            "ArmorDivisor": 1.0,
+            "Notes": ""
           }
         ]
       },
       "examples": [
         [
           {
-            "idkey": "",
-            "name": "Holdout Pistol, 7.5mmCLP",
-            "damage": "2d6",
-            "type": "pi",
-            "acc": "1",
-            "range": "100/1200",
-            "rof": "3",
-            "shots": "18+1(3)/0.2",
-            "bulk": "-1",
-            "recoil": "2",
-            "skill": 15,
-            "reason_for_mod": "",
-            "malfunction": "17",
-            "malfunction_verify": true,
-            "malfunction_very_reliable": true,
-            "armor_divisor": 0.5,
-            "notes": ""
+            "Idkey": "10720_crossbow_primary",
+            "Name": "Crossbow (Armor Piercing) (Primary)",
+            "Damage": "3d6",
+            "Type": "imp",
+            "Acc": "2",
+            "Range": "100/200",
+            "Rof": "1",
+            "Shots": "",
+            "Bulk": "",
+            "Recoil": "1",
+            "Skill": 17.0,
+            "Malfunction": "",
+            "MalfunctionVerify": false,
+            "MalfunctionVeryReliable": false,
+            "ArmorDivisor": 2.0,
+            "Notes": ""
+          },
+          {
+            "Idkey": "10730_crossbow_primary",
+            "Name": "Crossbow (Explosive) (Primary)",
+            "Damage": "3d6",
+            "Type": "cr dkb ex/2",
+            "Acc": "2",
+            "Range": "200",
+            "Rof": "1",
+            "Shots": "n/a",
+            "Bulk": "",
+            "Recoil": "1",
+            "Skill": 17.0,
+            "Malfunction": "",
+            "MalfunctionVerify": false,
+            "MalfunctionVeryReliable": false,
+            "ArmorDivisor": 1.0,
+            "Notes": ""
+          },
+          {
+            "Idkey": "10786_revolver357m_",
+            "Name": "Revolver, .357M",
+            "Damage": "3d6-1",
+            "Type": "pi",
+            "Acc": "2",
+            "Range": "185/2000",
+            "Rof": "3",
+            "Shots": "6(3i)",
+            "Bulk": "-2",
+            "Recoil": "3",
+            "Skill": 15.0,
+            "Malfunction": "17",
+            "MalfunctionVerify": false,
+            "MalfunctionVeryReliable": false,
+            "ArmorDivisor": 1.0,
+            "Notes": ""
           }
         ]
       ]
     },
-    "repeating_item": {
+    "RepeatingItem": {
       "type": "array",
       "default": [],
-      "title": "The repeating_item Schema",
+      "title": "The RepeatingItem Schema",
       "items": {
         "type": "object",
         "title": "A Schema",
         "required": [
-          "idkey",
-          "name",
-          "tl",
-          "legality_class",
-          "ref",
-          "count",
-          "cost",
-          "weight",
-          "notes"
+          "Idkey",
+          "Name",
+          "Tl",
+          "LegalityClass",
+          "Ref",
+          "Count",
+          "Cost",
+          "Weight",
+          "Notes"
         ],
         "properties": {
-          "idkey": {
+          "Idkey": {
             "type": "string",
-            "title": "The idkey Schema",
+            "title": "The Idkey is the unique identifier, allowing the item to be easily re-imported.",
             "examples": [
-              ""
+              "10833",
+              "10790",
+              "13358",
+              "13176",
+              "13355",
+              "10788",
+              "10792",
+              "10786",
+              "13356"
             ]
           },
-          "name": {
+          "Name": {
             "type": "string",
-            "title": "The name Schema",
+            "title": "The Name Schema",
             "examples": [
-              "7mmCL Conventional Ammunition",
-              "Antitoxin Kit",
-              "Cell Phone",
-              "Holdout Pistol, 7.5mmCLP"
+              "Advanced Body Armor",
+              "Boots, Steel-Toed",
+              "Compass",
+              "Force Shield",
+              "Holster, Belt",
+              "Laser Sight",
+              "Personal Basics",
+              "Revolver, .357M",
+              "Revolver, .357M (Ammunition)"
             ]
           },
-          "tl": {
+          "Tl": {
             "type": "string",
-            "title": "The tl Schema",
+            "title": "The Tl Schema",
             "examples": [
-              "9",
+              "8",
               "6",
-              "8"
+              "^",
+              "5",
+              "0",
+              "7"
             ]
           },
-          "legality_class": {
+          "LegalityClass": {
             "type": "string",
-            "title": "The legality_class Schema",
+            "title": "The LegalityClass Schema",
             "examples": [
-              "3",
+              "2",
+              "4",
+              "",
+              "3"
+            ]
+          },
+          "Ref": {
+            "type": "string",
+            "title": "The Ref Schema",
+            "examples": [
+              "HT66",
+              "HT68",
+              "B288",
+              "B273, B287",
+              "B289",
+              "B278",
               ""
             ]
           },
-          "ref": {
-            "type": "string",
-            "title": "The ref Schema",
+          "Count": {
+            "type": "number",
+            "title": "The Count Schema",
             "examples": [
-              "UT139",
-              "B289",
-              "B288",
-              "UT137"
+              1.0,
+              12.0
             ]
           },
-          "count": {
-            "type": "integer",
-            "title": "The count Schema",
+          "Cost": {
+            "type": "number",
+            "title": "The Cost Schema",
             "examples": [
-              16,
-              1
+              4600.0,
+              100.0,
+              50.0,
+              1500.0,
+              1180.4,
+              5.0,
+              1100.0,
+              50.4
             ]
           },
-          "cost": {
-            "type": [
-              "number",
-              "integer"
-            ],
-            "title": "The cost Schema",
+          "Weight": {
+            "type": "number",
+            "title": "The Weight Schema",
             "examples": [
-              0.54,
-              25,
-              250,
-              240
-            ]
-          },
-          "weight": {
-            "type": [
-              "number",
-              "integer"
-            ],
-            "title": "The weight Schema",
-            "examples": [
-              0.027,
+              17.0,
+              4.0,
+              0.0,
               0.5,
-              0.25,
-              1
+              7.62,
+              1.0,
+              3.6,
+              2.52
             ]
           },
-          "notes": {
+          "Notes": {
             "type": "string",
-            "title": "The notes Schema",
+            "title": "The Notes Schema",
             "examples": [
-              "",
-              "Alcohol\n\nTL:6 Notes: Antidote for specific poison. 10 uses.",
-              "TL:8 Notes: Only works in some areas, $20/month fee. 10hrs.",
-              "HUD +1 ACC \u003c 300 yards. Laser Sight +1 Skill \u003c 1/2D Range. Recognition Grip. Diagnostic Chip +1 Repair\n\nTL:9 LC:3 Ammo:0.2 lb. Damage:2d pi Acc:1 Range:100/1200 RoF:3 Shots:18+1(3) ST:6 Bulk:-1 Rcl:2 Skill:Guns (Pistol"
+              "Signature Gear, +0\nTL:8 LC:2 DR:35/5* Location:torso Notes:[1] Concealable as or under clothing. [5] Use the lower DR versus crushing attacks only.",
+              "TL:6 LC:4 DR:6/2 Location:feet Notes:[1] Concealable as or under clothing. [2] Give +1 to kicking damage (p. B271). [4] Split DR: use the first, higher DR when - in the GM's opinion - the boot's steel toe box would protect (e. g. , dropping an item on the foot or crushing the toes in heavy machinery) or when an attack on the foot hits the toe (2/6 protection); use the second, lower DR against all other attacks.",
+              "TL:6 Notes: +1 to Navigation skill",
+              "TL:^ LC:3 DB:3 Dam:thr cr Reach:1 Parry:No ST:-- DR:100 HP:-- Skill:Shield (Force) Notes: [3,5] Also available as a buckler. You can ready a buckler in one turn and drop it as a free action, just like a weapon - but it always occupies one hand, and it does not allow a shield rush. Use Shield (Buckler) instead of regular shield skill. No effect on statistics. Worn on the wrist, leaving the hand free. DR is hardened (treat as Hardened enhancement, p. B47).",
+              "TL:5 Notes: Fits most pistols.",
+              "TL:8 Notes: +1 to skill, see Laser Sights (p. B412)",
+              "TL:0 Notes: Minimum gear for camping: -2 to any Survival roll without it. Includes utensils, tinderbox or flint and steel, towel, etc., as TL permits.",
+              "Rugged, *2\nReceives Skill Bonus, +1, +0\nTL:7 LC:3 Damage:3d-1 pi Acc:2 Range:185/2000 RoF:3 Shots:6(3i) ST:10 Bulk:-2 Rcl:3 Skill:Guns (Pistol)",
+              "Ammunition"
             ]
           }
         },
         "examples": [
           {
-            "idkey": "",
-            "name": "7mmCL Conventional Ammunition",
-            "tl": "9",
-            "legality_class": "3",
-            "ref": "UT139",
-            "count": 16,
-            "cost": 0.54,
-            "weight": 0.027,
-            "notes": ""
+            "Idkey": "10833",
+            "Name": "Advanced Body Armor",
+            "Tl": "8",
+            "LegalityClass": "2",
+            "Ref": "HT66",
+            "Count": 1.0,
+            "Cost": 4600.0,
+            "Weight": 17.0,
+            "Notes": "Signature Gear, +0\nTL:8 LC:2 DR:35/5* Location:torso Notes:[1] Concealable as or under clothing. [5] Use the lower DR versus crushing attacks only."
           },
           {
-            "idkey": "",
-            "name": "Antitoxin Kit",
-            "tl": "6",
-            "legality_class": "",
-            "ref": "B289",
-            "count": 1,
-            "cost": 25,
-            "weight": 0.5,
-            "notes": "Alcohol\n\nTL:6 Notes: Antidote for specific poison. 10 uses."
+            "Idkey": "10790",
+            "Name": "Boots, Steel-Toed",
+            "Tl": "6",
+            "LegalityClass": "4",
+            "Ref": "HT68",
+            "Count": 1.0,
+            "Cost": 100.0,
+            "Weight": 4.0,
+            "Notes": "TL:6 LC:4 DR:6/2 Location:feet Notes:[1] Concealable as or under clothing. [2] Give +1 to kicking damage (p. B271). [4] Split DR: use the first, higher DR when - in the GM's opinion - the boot's steel toe box would protect (e. g. , dropping an item on the foot or crushing the toes in heavy machinery) or when an attack on the foot hits the toe (2/6 protection); use the second, lower DR against all other attacks."
           },
           {
-            "idkey": "",
-            "name": "Cell Phone",
-            "tl": "8",
-            "legality_class": "",
-            "ref": "B288",
-            "count": 1,
-            "cost": 250,
-            "weight": 0.25,
-            "notes": "TL:8 Notes: Only works in some areas, $20/month fee. 10hrs."
+            "Idkey": "13358",
+            "Name": "Compass",
+            "Tl": "6",
+            "LegalityClass": "",
+            "Ref": "B288",
+            "Count": 1.0,
+            "Cost": 50.0,
+            "Weight": 0.0,
+            "Notes": "TL:6 Notes: +1 to Navigation skill"
           },
           {
-            "idkey": "",
-            "name": "Holdout Pistol, 7.5mmCLP",
-            "tl": "9",
-            "legality_class": "3",
-            "ref": "UT137",
-            "count": 1,
-            "cost": 240,
-            "weight": 1,
-            "notes": "HUD +1 ACC \u003c 300 yards. Laser Sight +1 Skill \u003c 1/2D Range. Recognition Grip. Diagnostic Chip +1 Repair\n\nTL:9 LC:3 Ammo:0.2 lb. Damage:2d pi Acc:1 Range:100/1200 RoF:3 Shots:18+1(3) ST:6 Bulk:-1 Rcl:2 Skill:Guns (Pistol"
+            "Idkey": "13176",
+            "Name": "Force Shield",
+            "Tl": "^",
+            "LegalityClass": "3",
+            "Ref": "B273, B287",
+            "Count": 1.0,
+            "Cost": 1500.0,
+            "Weight": 0.5,
+            "Notes": "TL:^ LC:3 DB:3 Dam:thr cr Reach:1 Parry:No ST:-- DR:100 HP:-- Skill:Shield (Force) Notes: [3,5] Also available as a buckler. You can ready a buckler in one turn and drop it as a free action, just like a weapon - but it always occupies one hand, and it does not allow a shield rush. Use Shield (Buckler) instead of regular shield skill. No effect on statistics. Worn on the wrist, leaving the hand free. DR is hardened (treat as Hardened enhancement, p. B47)."
+          },
+          {
+            "Idkey": "13355",
+            "Name": "Holster, Belt",
+            "Tl": "5",
+            "LegalityClass": "",
+            "Ref": "B289",
+            "Count": 1.0,
+            "Cost": 1180.4,
+            "Weight": 7.62,
+            "Notes": "TL:5 Notes: Fits most pistols."
+          },
+          {
+            "Idkey": "10788",
+            "Name": "Laser Sight",
+            "Tl": "8",
+            "LegalityClass": "",
+            "Ref": "B289",
+            "Count": 1.0,
+            "Cost": 100.0,
+            "Weight": 0.0,
+            "Notes": "TL:8 Notes: +1 to skill, see Laser Sights (p. B412)"
+          },
+          {
+            "Idkey": "10792",
+            "Name": "Personal Basics",
+            "Tl": "0",
+            "LegalityClass": "",
+            "Ref": "B288",
+            "Count": 1.0,
+            "Cost": 5.0,
+            "Weight": 1.0,
+            "Notes": "TL:0 Notes: Minimum gear for camping: -2 to any Survival roll without it. Includes utensils, tinderbox or flint and steel, towel, etc., as TL permits."
+          },
+          {
+            "Idkey": "10786",
+            "Name": "Revolver, .357M",
+            "Tl": "7",
+            "LegalityClass": "3",
+            "Ref": "B278",
+            "Count": 1.0,
+            "Cost": 1100.0,
+            "Weight": 3.6,
+            "Notes": "Rugged, *2\nReceives Skill Bonus, +1, +0\nTL:7 LC:3 Damage:3d-1 pi Acc:2 Range:185/2000 RoF:3 Shots:6(3i) ST:10 Bulk:-2 Rcl:3 Skill:Guns (Pistol)"
+          },
+          {
+            "Idkey": "13356",
+            "Name": "Revolver, .357M (Ammunition)",
+            "Tl": "7",
+            "LegalityClass": "3",
+            "Ref": "",
+            "Count": 12.0,
+            "Cost": 50.4,
+            "Weight": 2.52,
+            "Notes": "Ammunition"
           }
         ]
       },
       "examples": [
         [
           {
-            "idkey": "",
-            "name": "7mmCL Conventional Ammunition",
-            "tl": "9",
-            "legality_class": "3",
-            "ref": "UT139",
-            "count": 16,
-            "cost": 0.54,
-            "weight": 0.027,
-            "notes": ""
+            "Idkey": "10833",
+            "Name": "Advanced Body Armor",
+            "Tl": "8",
+            "LegalityClass": "2",
+            "Ref": "HT66",
+            "Count": 1.0,
+            "Cost": 4600.0,
+            "Weight": 17.0,
+            "Notes": "Signature Gear, +0\nTL:8 LC:2 DR:35/5* Location:torso Notes:[1] Concealable as or under clothing. [5] Use the lower DR versus crushing attacks only."
           },
           {
-            "idkey": "",
-            "name": "Antitoxin Kit",
-            "tl": "6",
-            "legality_class": "",
-            "ref": "B289",
-            "count": 1,
-            "cost": 25,
-            "weight": 0.5,
-            "notes": "Alcohol\n\nTL:6 Notes: Antidote for specific poison. 10 uses."
+            "Idkey": "10790",
+            "Name": "Boots, Steel-Toed",
+            "Tl": "6",
+            "LegalityClass": "4",
+            "Ref": "HT68",
+            "Count": 1.0,
+            "Cost": 100.0,
+            "Weight": 4.0,
+            "Notes": "TL:6 LC:4 DR:6/2 Location:feet Notes:[1] Concealable as or under clothing. [2] Give +1 to kicking damage (p. B271). [4] Split DR: use the first, higher DR when - in the GM's opinion - the boot's steel toe box would protect (e. g. , dropping an item on the foot or crushing the toes in heavy machinery) or when an attack on the foot hits the toe (2/6 protection); use the second, lower DR against all other attacks."
           },
           {
-            "idkey": "",
-            "name": "Cell Phone",
-            "tl": "8",
-            "legality_class": "",
-            "ref": "B288",
-            "count": 1,
-            "cost": 250,
-            "weight": 0.25,
-            "notes": "TL:8 Notes: Only works in some areas, $20/month fee. 10hrs."
+            "Idkey": "13358",
+            "Name": "Compass",
+            "Tl": "6",
+            "LegalityClass": "",
+            "Ref": "B288",
+            "Count": 1.0,
+            "Cost": 50.0,
+            "Weight": 0.0,
+            "Notes": "TL:6 Notes: +1 to Navigation skill"
           },
           {
-            "idkey": "",
-            "name": "Holdout Pistol, 7.5mmCLP",
-            "tl": "9",
-            "legality_class": "3",
-            "ref": "UT137",
-            "count": 1,
-            "cost": 240,
-            "weight": 1,
-            "notes": "HUD +1 ACC \u003c 300 yards. Laser Sight +1 Skill \u003c 1/2D Range. Recognition Grip. Diagnostic Chip +1 Repair\n\nTL:9 LC:3 Ammo:0.2 lb. Damage:2d pi Acc:1 Range:100/1200 RoF:3 Shots:18+1(3) ST:6 Bulk:-1 Rcl:2 Skill:Guns (Pistol"
+            "Idkey": "13176",
+            "Name": "Force Shield",
+            "Tl": "^",
+            "LegalityClass": "3",
+            "Ref": "B273, B287",
+            "Count": 1.0,
+            "Cost": 1500.0,
+            "Weight": 0.5,
+            "Notes": "TL:^ LC:3 DB:3 Dam:thr cr Reach:1 Parry:No ST:-- DR:100 HP:-- Skill:Shield (Force) Notes: [3,5] Also available as a buckler. You can ready a buckler in one turn and drop it as a free action, just like a weapon - but it always occupies one hand, and it does not allow a shield rush. Use Shield (Buckler) instead of regular shield skill. No effect on statistics. Worn on the wrist, leaving the hand free. DR is hardened (treat as Hardened enhancement, p. B47)."
+          },
+          {
+            "Idkey": "13355",
+            "Name": "Holster, Belt",
+            "Tl": "5",
+            "LegalityClass": "",
+            "Ref": "B289",
+            "Count": 1.0,
+            "Cost": 1180.4,
+            "Weight": 7.62,
+            "Notes": "TL:5 Notes: Fits most pistols."
+          },
+          {
+            "Idkey": "10788",
+            "Name": "Laser Sight",
+            "Tl": "8",
+            "LegalityClass": "",
+            "Ref": "B289",
+            "Count": 1.0,
+            "Cost": 100.0,
+            "Weight": 0.0,
+            "Notes": "TL:8 Notes: +1 to skill, see Laser Sights (p. B412)"
+          },
+          {
+            "Idkey": "10792",
+            "Name": "Personal Basics",
+            "Tl": "0",
+            "LegalityClass": "",
+            "Ref": "B288",
+            "Count": 1.0,
+            "Cost": 5.0,
+            "Weight": 1.0,
+            "Notes": "TL:0 Notes: Minimum gear for camping: -2 to any Survival roll without it. Includes utensils, tinderbox or flint and steel, towel, etc., as TL permits."
+          },
+          {
+            "Idkey": "10786",
+            "Name": "Revolver, .357M",
+            "Tl": "7",
+            "LegalityClass": "3",
+            "Ref": "B278",
+            "Count": 1.0,
+            "Cost": 1100.0,
+            "Weight": 3.6,
+            "Notes": "Rugged, *2\nReceives Skill Bonus, +1, +0\nTL:7 LC:3 Damage:3d-1 pi Acc:2 Range:185/2000 RoF:3 Shots:6(3i) ST:10 Bulk:-2 Rcl:3 Skill:Guns (Pistol)"
+          },
+          {
+            "Idkey": "13356",
+            "Name": "Revolver, .357M (Ammunition)",
+            "Tl": "7",
+            "LegalityClass": "3",
+            "Ref": "",
+            "Count": 12.0,
+            "Cost": 50.4,
+            "Weight": 2.52,
+            "Notes": "Ammunition"
           }
         ]
       ]
     },
-    "repeating_spells": {
+    "RepeatingSpells": {
       "type": "array",
       "default": [],
-      "title": "The repeating_spells Schema",
-      "items": {
-        "type": "object",
-        "title": "A Schema",
-        "required": [
-          "idkey",
-          "name",
-          "difficulty",
-          "spell_modifier",
-          "points",
-          "spell_resisted_by",
-          "duration",
-          "cost",
-          "casttime",
-          "maintain",
-          "spell_class",
-          "spell_college",
-          "spell_college_secondary",
-          "spell_mod_notes",
-          "spell_notes"
-        ],
-        "properties": {
-          "idkey": {
-            "type": "string",
-            "title": "The idkey Schema",
-            "examples": [
-              ""
-            ]
-          },
-          "name": {
-            "type": "string",
-            "title": "The name Schema",
-            "examples": [
-              "Air Jet",
-              "Fireball"
-            ]
-          },
-          "difficulty": {
-            "type": "string",
-            "title": "The difficulty Schema",
-            "examples": [
-              "H"
-            ]
-          },
-          "spell_modifier": {
-            "type": "integer",
-            "title": "The spell_modifier Schema",
-            "examples": [
-              2,
-              0
-            ]
-          },
-          "points": {
-            "type": "integer",
-            "title": "The points Schema",
-            "examples": [
-              2
-            ]
-          },
-          "spell_resisted_by": {
-            "type": "string",
-            "title": "The spell_resisted_by Schema",
-            "examples": [
-              ""
-            ]
-          },
-          "duration": {
-            "type": "string",
-            "title": "The duration Schema",
-            "examples": [
-              "1 sec.",
-              "Instant"
-            ]
-          },
-          "cost": {
-            "type": "string",
-            "title": "The cost Schema",
-            "examples": [
-              "1 to 3/S",
-              "1 to Magery#"
-            ]
-          },
-          "casttime": {
-            "type": "string",
-            "title": "The casttime Schema",
-            "examples": [
-              "1 sec.",
-              "1 to 3 sec."
-            ]
-          },
-          "maintain": {
-            "type": "string",
-            "title": "The maintain Schema",
-            "examples": [
-              ""
-            ]
-          },
-          "spell_class": {
-            "type": "string",
-            "title": "The spell_class Schema",
-            "examples": [
-              "Regular",
-              "Missile"
-            ]
-          },
-          "spell_college": {
-            "type": "string",
-            "title": "The spell_college Schema",
-            "examples": [
-              "Air",
-              "Fire"
-            ]
-          },
-          "spell_college_secondary": {
-            "type": "string",
-            "title": "The spell_college_secondary Schema",
-            "examples": [
-              ""
-            ]
-          },
-          "spell_mod_notes": {
-            "type": "string",
-            "title": "The spell_mod_notes Schema",
-            "examples": [
-              ""
-            ]
-          },
-          "spell_notes": {
-            "type": "string",
-            "title": "The spell_notes Schema",
-            "examples": [
-              "Prereq Count: 3 Prerequisites: Shape Air\n\nNeeds: Shape Air, ST:Magery = 0 | PE:Charms ([Spell]) | PE:Charms (%SpellsList%) | PE:Charms (Air Jet)",
-              "Prereq Count: 3 Prerequisites: Magery 1, Create Fire, Shape Fire\n\nNeeds: (AD:Magery 0 | ST:Magery 0 = 1), (AD:Magery = 1, ST:Magery = 1 | ST:Magery Fire = 1), Create Fire, Shape Fire, ST:Magery = 0 | PE:Charms ([Spell]) | PE:Charms (%SpellsList%) | PE:Charms (Fireball),"
-            ]
-          }
-        },
-        "examples": [
-          {
-            "idkey": "",
-            "name": "Air Jet",
-            "difficulty": "H",
-            "spell_modifier": 2,
-            "points": 2,
-            "spell_resisted_by": "",
-            "duration": "1 sec.",
-            "cost": "1 to 3/S",
-            "casttime": "1 sec.",
-            "maintain": "",
-            "spell_class": "Regular",
-            "spell_college": "Air",
-            "spell_college_secondary": "",
-            "spell_mod_notes": "",
-            "spell_notes": "Prereq Count: 3 Prerequisites: Shape Air\n\nNeeds: Shape Air, ST:Magery = 0 | PE:Charms ([Spell]) | PE:Charms (%SpellsList%) | PE:Charms (Air Jet)"
-          },
-          {
-            "idkey": "",
-            "name": "Fireball",
-            "difficulty": "H",
-            "spell_modifier": 0,
-            "points": 2,
-            "spell_resisted_by": "",
-            "duration": "Instant",
-            "cost": "1 to Magery#",
-            "casttime": "1 to 3 sec.",
-            "maintain": "",
-            "spell_class": "Missile",
-            "spell_college": "Fire",
-            "spell_college_secondary": "",
-            "spell_mod_notes": "",
-            "spell_notes": "Prereq Count: 3 Prerequisites: Magery 1, Create Fire, Shape Fire\n\nNeeds: (AD:Magery 0 | ST:Magery 0 = 1), (AD:Magery = 1, ST:Magery = 1 | ST:Magery Fire = 1), Create Fire, Shape Fire, ST:Magery = 0 | PE:Charms ([Spell]) | PE:Charms (%SpellsList%) | PE:Charms (Fireball),"
-          }
-        ]
-      },
+      "title": "The RepeatingSpells Schema",
+      "items": {},
       "examples": [
-        [
-          {
-            "idkey": "",
-            "name": "Air Jet",
-            "difficulty": "H",
-            "spell_modifier": 2,
-            "points": 2,
-            "spell_resisted_by": "",
-            "duration": "1 sec.",
-            "cost": "1 to 3/S",
-            "casttime": "1 sec.",
-            "maintain": "",
-            "spell_class": "Regular",
-            "spell_college": "Air",
-            "spell_college_secondary": "",
-            "spell_mod_notes": "",
-            "spell_notes": "Prereq Count: 3 Prerequisites: Shape Air\n\nNeeds: Shape Air, ST:Magery = 0 | PE:Charms ([Spell]) | PE:Charms (%SpellsList%) | PE:Charms (Air Jet)"
-          },
-          {
-            "idkey": "",
-            "name": "Fireball",
-            "difficulty": "H",
-            "spell_modifier": 0,
-            "points": 2,
-            "spell_resisted_by": "",
-            "duration": "Instant",
-            "cost": "1 to Magery#",
-            "casttime": "1 to 3 sec.",
-            "maintain": "",
-            "spell_class": "Missile",
-            "spell_college": "Fire",
-            "spell_college_secondary": "",
-            "spell_mod_notes": "",
-            "spell_notes": "Prereq Count: 3 Prerequisites: Magery 1, Create Fire, Shape Fire\n\nNeeds: (AD:Magery 0 | ST:Magery 0 = 1), (AD:Magery = 1, ST:Magery = 1 | ST:Magery Fire = 1), Create Fire, Shape Fire, ST:Magery = 0 | PE:Charms ([Spell]) | PE:Charms (%SpellsList%) | PE:Charms (Fireball),"
-          }
-        ]
-      ]
-    },
-    "final_values": {
-      "type": "object",
-      "default": {},
-      "title": "The final_values Schema",
-      "required": [
-        "combat_reflexes"
-      ],
-      "properties": {
-        "combat_reflexes": {
-          "type": "boolean",
-          "default": false,
-          "title": "The combat_reflexes Schema",
-          "examples": [
-            true
-          ]
-        }
-      },
-      "examples": [
-        {
-          "combat_reflexes": true
-        }
+        []
       ]
     }
   },
   "examples": [
     {
-      "character_name": "Bartholomew Mactavish",
-      "fullname": "Bartholomew Mactavish",
-      "playername": "NPC",
-      "nickname": "Bart",
-      "race": "Human",
-      "race_ref": "",
-      "template_names": "Hill People",
-      "gender": "Male",
-      "size": 0,
-      "apply_size_modifier": false,
-      "reactions": "",
-      "campaign_tl": 9,
-      "tl": 9,
-      "tl_pts": 0,
-      "status": "0",
-      "wealth": "Average",
-      "income": 700,
-      "cost_of_living": 600,
-      "stash": 100,
-      "age": 33,
-      "height": "5' 7\"",
-      "weight": 180,
-      "appearance": 4,
-      "general_appearance": "scruffy, nerf herder.",
-      "strength_mod": 0,
-      "strength_points": 10,
-      "dexterity_mod": 0,
-      "dexterity_points": 40,
-      "intelligence_mod": 40,
-      "health_mod": 0,
-      "health_points": 10,
-      "perception_mod": 0,
-      "perception_points": 0,
-      "vision_mod": 0,
-      "hearing_mod": 0,
-      "hearing_points": 0,
-      "taste_smell_mod": 0,
-      "taste_smell_points": 0,
-      "touch_mod": 0,
-      "willpower_mod": 0,
-      "willpower_points": 0,
-      "fear_check_mod": 2,
-      "fear_check_points": 0,
-      "stun_check_mod": 0,
-      "knockdown_check_mod": 0,
-      "unconscious_check_mod": 0,
-      "unconscious_check_points": 0,
-      "death_check_mod": 0,
-      "death_check_points": 0,
-      "basic_speed_mod": 0,
-      "basic_speed_points": 0,
-      "basic_move_mod": 0,
-      "basic_move_points": 0,
-      "enhanced_ground_move_mod": 0,
-      "enhanced_ground_move_points": 0,
-      "dodge_mod": 1,
-      "lift_st_mod": 0,
-      "lift_st_points": 0,
-      "striking_st_mod": 0,
-      "striking_st_points": 0,
-      "hit_points_mod": 0,
-      "hit_points_points": 0,
-      "hit_points": 11,
-      "fatigue_points_mod": 0,
-      "fatigue_points_points": 0,
-      "fatigue_points": 11,
-      "flight_checked": false,
-      "flight_points": 0,
-      "basic_air_move_mod": 0,
-      "basic_air_move_points": 0,
-      "enhanced_air_level": 0,
-      "enhanced_air_move_points": 0,
-      "amphibious_checked": false,
-      "amphibious_points": 0,
-      "basic_water_move_mod": 0,
-      "basic_water_move_points": 0,
-      "enhanced_water_level": 0,
-      "enhanced_water_move_points": 0,
-      "super_jump_entered_level": 0,
-      "super_jump_points": 0,
-      "spell_bonus": 0,
-      "repeating_languages": [
+      "CharacterName": "Rampage",
+      "Fullname": "Rampage (NPC)",
+      "Playername": "NPC",
+      "Nickname": "",
+      "Race": "Human",
+      "RaceRef": "",
+      "TemplateNames": "",
+      "Gender": "",
+      "Size": 0.0,
+      "ApplySizeModifier": false,
+      "Reactions": "+2 from 'Charisma 2'\nConditional:\n-2 from 'Reputation 2 (Gang Leader; 7 or less, +1, *1/3; Large class, +1, *1/2)'",
+      "CampaignTl": 8.0,
+      "TotalPoints": 150.0,
+      "Tl": 8.0,
+      "TlPts": 0.0,
+      "Status": "0",
+      "Wealth": "Comfortable",
+      "Income": 5200.0,
+      "CostOfLiving": 600.0,
+      "Stash": 5169.6,
+      "Age": "27",
+      "Height": "6'",
+      "Weight": 210.0,
+      "Appearance": 0.0,
+      "GeneralAppearance": "Short mohawk, painted face, likes to wear chains, like something out of Road Warrior.",
+      "StrengthMod": 1.0,
+      "StrengthPoints": 60.0,
+      "DexterityMod": 0.0,
+      "DexterityPoints": 40.0,
+      "IntelligenceMod": 0.0,
+      "IntelligencePoints": 0.0,
+      "HealthMod": 0.0,
+      "HealthPoints": 20.0,
+      "PerceptionMod": 0.0,
+      "PerceptionPoints": 10.0,
+      "VisionMod": 0.0,
+      "VisionPoints": 0.0,
+      "HearingMod": 0.0,
+      "HearingPoints": 0.0,
+      "TasteSmellMod": 0.0,
+      "TasteSmellPoints": 0.0,
+      "TouchMod": 0.0,
+      "TouchPoints": 0.0,
+      "WillpowerMod": 0.0,
+      "WillpowerPoints": 10.0,
+      "FearCheckMod": 2.0,
+      "FearCheckPoints": 0.0,
+      "StunCheckMod": 0.0,
+      "KnockdownCheckMod": 0.0,
+      "UnconsciousCheckMod": 1.0,
+      "UnconsciousCheckPoints": 0.0,
+      "DeathCheckMod": 1.0,
+      "DeathCheckPoints": 0.0,
+      "BasicSpeedMod": 0.0,
+      "BasicSpeedPoints": 0.0,
+      "BasicMoveMod": 0.0,
+      "BasicMovePoints": 0.0,
+      "EnhancedGroundMoveMod": 0.5,
+      "EnhancedGroundMovePoints": 0.0,
+      "DodgeMod": 2.0,
+      "LiftStMod": 7.0,
+      "LiftStPoints": 15.0,
+      "StrikingStMod": 4.0,
+      "StrikingStPoints": 0.0,
+      "HitPointsMod": 0.0,
+      "HitPointsPoints": 8.0,
+      "HitPoints": 21.0,
+      "FatiguePointsMod": 0.0,
+      "FatiguePointsPoints": 0.0,
+      "FatiguePoints": 12.0,
+      "FlightChecked": false,
+      "FlightPoints": 0.0,
+      "BasicAirMoveMod": 0.0,
+      "BasicAirMovePoints": 0.0,
+      "EnhancedAirLevel": 0.0,
+      "EnhancedAirMovePoints": 0.0,
+      "AmphibiousChecked": false,
+      "AmphibiousPoints": 0.0,
+      "BasicWaterMoveMod": 0.0,
+      "BasicWaterMovePoints": 0.0,
+      "EnhancedWaterLevel": 0.0,
+      "EnhancedWaterMovePoints": 0.0,
+      "SuperJumpEnteredLevel": 0.0,
+      "SuperJumpPoints": 0.0,
+      "SpellBonus": 0.0,
+      "CombatReflexes": true,
+      "RepeatingLanguages": [
         {
-          "idkey": "184",
-          "name": "English",
-          "spoken": 3,
-          "written": 3,
-          "is_native": true
+          "Idkey": "10663",
+          "Name": "English",
+          "Spoken": 0.0,
+          "Written": 0.0,
+          "IsNative": true
         },
         {
-          "idkey": "187",
-          "name": "Spanish",
-          "spoken": 2,
-          "written": 2,
-          "is_native": false
+          "Idkey": "12985",
+          "Name": "French",
+          "Spoken": 2.0,
+          "Written": 1.0,
+          "IsNative": false
         },
         {
-          "idkey": "186",
-          "name": "Street Speach (Spoken)",
-          "spoken": 2,
-          "written": 0,
-          "is_native": false
+          "Idkey": "12984",
+          "Name": "German",
+          "Spoken": 2.0,
+          "Written": 2.0,
+          "IsNative": false
         }
       ],
-      "repeating_cultures": [
+      "RepeatingCultures": [
         {
-          "idkey": "",
-          "name": "Western",
-          "points": 0
+          "Idkey": "12982",
+          "Name": "European (Native)",
+          "Points": 0.0
+        },
+        {
+          "Idkey": "12983",
+          "Name": "Western",
+          "Points": 1.0
         }
       ],
-      "repeating_traits": [
+      "RepeatingTraits": [
         {
-          "idkey": "192",
-          "name": "Advanced Bionic Ear TL9",
-          "trait_level": "1",
-          "foa": "",
-          "points": 11,
-          "ref": "B44",
-          "notes": "Based On: _New Advanage\n\nDiscriminatory Hearing (Temporary Disadvantage, Electrical, -20%)[12];Protected Hearing[5];Deafness (Mitigator -70%)[-6]"
+          "Idkey": "10717",
+          "Name": "Ambidexterity",
+          "TraitLevel": "1",
+          "Foa": "",
+          "Points": 5.0,
+          "Ref": "B39",
+          "Notes": ""
         },
         {
-          "idkey": "189",
-          "name": "Contact (Cybernetic Street Engineer) (Effective Skill 12)",
-          "trait_level": "1",
-          "foa": "9",
-          "points": 1,
-          "ref": "B44",
-          "notes": "Modifiers:\nFrequency: roll of 9 or less, *1\nReliability: Somewhat Reliable, *1"
+          "Idkey": "10800",
+          "Name": "Appearance",
+          "TraitLevel": "1",
+          "Foa": "",
+          "Points": 4.0,
+          "Ref": "B21",
+          "Notes": "Attractive"
         },
         {
-          "idkey": "147",
-          "name": "Danger Sense",
-          "trait_level": "1",
-          "foa": "",
-          "points": 15,
-          "ref": "B47",
-          "notes": ""
+          "Idkey": "10704",
+          "Name": "Body Control Talent",
+          "TraitLevel": "1",
+          "Foa": "",
+          "Points": 5.0,
+          "Ref": "P121,P167-169",
+          "Notes": "Innate Attack (Projectile), +0"
+        },
+        {
+          "Idkey": "10799",
+          "Name": "Charisma",
+          "TraitLevel": "2",
+          "Foa": "",
+          "Points": 10.0,
+          "Ref": "B41",
+          "Notes": ""
+        },
+        {
+          "Idkey": "10698",
+          "Name": "Combat Reflexes",
+          "TraitLevel": "1",
+          "Foa": "",
+          "Points": 14.0,
+          "Ref": "B43",
+          "Notes": "Biological, -10%"
+        },
+        {
+          "Idkey": "12986",
+          "Name": "Contact (Rival Gang)",
+          "TraitLevel": "1",
+          "Foa": "9",
+          "Points": 1.0,
+          "Ref": "B44",
+          "Notes": "My notes here\nEffective Skill 12\nRival Gang\n9 or less, *1\nSomewhat Reliable, *1\nMy notes here\nUgly dude with twisted lips"
+        },
+        {
+          "Idkey": "10720",
+          "Name": "Crossbow (Armor Piercing)",
+          "TraitLevel": "3",
+          "Foa": "",
+          "Points": 38.0,
+          "Ref": "B61, P53",
+          "Notes": "Armor Piercing\nArmor Divisor, 2, +50%\nGadget/Breakable: DR 3-5, -15%\nGadget/Breakable: Size -3 or -4, -15%\nGadget/Can Be Stolen: Must be forcefully removed, -10%\nInaccurate, -1, -5%\nIncreased Range, x2, +10%\nIncreased Range, 1/2D Range only, x5, +10%\nNo Signature, +20%\nRicochet, +10%"
+        },
+        {
+          "Idkey": "10730",
+          "Name": "Crossbow (Explosive)",
+          "TraitLevel": "3",
+          "Foa": "",
+          "Points": 7.0,
+          "Ref": "B61, P53",
+          "Notes": "Explosive\nAlternative Attack, *1/5\nDouble Knockback, +20%\nExplosive, Damage / 2xYards, +100%\nGadget/Breakable: DR 3-5, -15%\nGadget/Breakable: Size -3 or -4, -15%\nGadget/Can Be Stolen: Must be forcefully removed, -10%\nInaccurate, -1, -5%\nIncreased Range, x2, +10%\nIncreased Range, 1/2D Range only, x10, +15%\nNo Signature, +20%"
+        },
+        {
+          "Idkey": "10741",
+          "Name": "Crossbow (Smoke Arrow)",
+          "TraitLevel": "6",
+          "Foa": "",
+          "Points": 5.0,
+          "Ref": "B72, P64",
+          "Notes": "Smoke Arrow\nAlternative Ability, *1/5\nArea Effect, 4 yd, +50%\nGadget/Breakable: DR 3-5, -15%\nGadget/Breakable: Size -3 or -4, -15%\nGadget/Can Be Stolen: Must be forcefully removed, -10%\nInaccurate, -1, -5%\nIncreased Range, x2, +10%\nIncreased Range, 1/2D Range Only, x5, +10%\nNo Signature, +20%\nRanged, +50%"
+        },
+        {
+          "Idkey": "10666",
+          "Name": "Damage Resistance",
+          "TraitLevel": "2",
+          "Foa": "",
+          "Points": 5.0,
+          "Ref": "B46, P45",
+          "Notes": "Biological, -10%\nTough Skin, -40%"
+        },
+        {
+          "Idkey": "10700",
+          "Name": "Enhanced Dodge",
+          "TraitLevel": "1",
+          "Foa": "",
+          "Points": 14.0,
+          "Ref": "B51",
+          "Notes": "Biological, -10%"
+        },
+        {
+          "Idkey": "10715",
+          "Name": "Enhanced Move (Ground)",
+          "TraitLevel": "1",
+          "Foa": "",
+          "Points": 9.0,
+          "Ref": "B52, P49",
+          "Notes": "#list(LevelName Step 0.5)\nGround\nBiological, -10%"
+        },
+        {
+          "Idkey": "10702",
+          "Name": "Enhanced Muscle",
+          "TraitLevel": "4",
+          "Foa": "",
+          "Points": 29.0,
+          "Ref": "Bio213",
+          "Notes": "Biological, -10%"
+        },
+        {
+          "Idkey": "10718",
+          "Name": "Extra Attack",
+          "TraitLevel": "1",
+          "Foa": "",
+          "Points": 23.0,
+          "Ref": "B54, P49",
+          "Notes": "Biological, -10%"
+        },
+        {
+          "Idkey": "11893",
+          "Name": "Extra ST",
+          "TraitLevel": "1",
+          "Foa": "",
+          "Points": 10.0,
+          "Ref": "B14",
+          "Notes": "Affects ST, +0%\nSize, +0%\nThe Extra ST advantage allows you to take extra levels of the attribute which you can then apply enhancements and limitations to. The \"Affects displayed score\" modifier causes the Extra ST advantage to affect the displayed attribute score. If you don't wish this advantage to affect the displayed score remove that modifier."
+        },
+        {
+          "Idkey": "10712",
+          "Name": "Fit",
+          "TraitLevel": "1",
+          "Foa": "",
+          "Points": 5.0,
+          "Ref": "B55",
+          "Notes": ""
+        },
+        {
+          "Idkey": "11891",
+          "Name": "Lifting ST",
+          "TraitLevel": "3",
+          "Foa": "",
+          "Points": 9.0,
+          "Ref": "B65, P58",
+          "Notes": "Size, +0%"
+        },
+        {
+          "Idkey": "10709",
+          "Name": "Protected Vision",
+          "TraitLevel": "1",
+          "Foa": "",
+          "Points": 5.0,
+          "Ref": "B78, P69",
+          "Notes": "Biological, -10%"
+        },
+        {
+          "Idkey": "10714",
+          "Name": "Rapid Healing",
+          "TraitLevel": "1",
+          "Foa": "",
+          "Points": 5.0,
+          "Ref": "B79",
+          "Notes": ""
+        },
+        {
+          "Idkey": "10711",
+          "Name": "Resilience",
+          "TraitLevel": "20",
+          "Foa": "",
+          "Points": 18.0,
+          "Ref": "",
+          "Notes": "Biological, -10%"
+        },
+        {
+          "Idkey": "10705",
+          "Name": "Resistant (Metabolic Hazards)",
+          "TraitLevel": "4",
+          "Foa": "",
+          "Points": 9.0,
+          "Ref": "B80, P71",
+          "Notes": "Very Common\nMetabolic Hazards\nBiological, -10%\n+3, *1/3"
+        },
+        {
+          "Idkey": "10835",
+          "Name": "Signature Gear (Advanced Body Armor)",
+          "TraitLevel": "1",
+          "Foa": "",
+          "Points": 1.0,
+          "Ref": "B85",
+          "Notes": "%SigGearAliasList%\nAdvanced Body Armor"
+        },
+        {
+          "Idkey": "11890",
+          "Name": "Wealth",
+          "TraitLevel": "1",
+          "Foa": "",
+          "Points": 10.0,
+          "Ref": "B25",
+          "Notes": "Comfortable"
         }
       ],
-      "repeating_perks": [
+      "RepeatingPerks": [
         {
-          "idkey": "129",
-          "name": "Alcohol Tolerance",
-          "foa": "",
-          "points": 1,
-          "ref": "B100, B100,PU2:13",
-          "notes": ""
+          "Idkey": "10756",
+          "Name": "Alcohol Tolerance",
+          "Foa": "",
+          "Points": 1.0,
+          "Ref": "B100, B100,PU2:13",
+          "Notes": ""
         },
         {
-          "idkey": "204",
-          "name": "Forgettable Face",
-          "foa": "12",
-          "points": 1,
-          "ref": "PU2:4",
-          "notes": ""
+          "Idkey": "10757",
+          "Name": "Base (Bar)",
+          "Foa": "",
+          "Points": 1.0,
+          "Ref": "PU2:17",
+          "Notes": "Bar"
         },
         {
-          "idkey": "205",
-          "name": "Illegal Gear - AP Bullets",
-          "foa": "",
-          "points": 1,
-          "ref": "",
-          "notes": ""
-        },
-        {
-          "idkey": "202",
-          "name": "License (Holdout Pistol)",
-          "foa": "",
-          "points": 1,
-          "ref": "PU2:18",
-          "notes": ""
+          "Idkey": "10794",
+          "Name": "Teamwork (Concrete Savages)",
+          "Foa": "",
+          "Points": 1.0,
+          "Ref": "MA52, PU2:6",
+          "Notes": "Concrete Savages"
         }
       ],
-      "repeating_quirks": [
+      "RepeatingQuirks": [
         {
-          "idkey": "216",
-          "name": "Avoids the spying on spouse jobs",
-          "control_rating": "12",
-          "points": "-1",
-          "ref": "B163",
-          "notes": ""
+          "Idkey": "10774",
+          "Name": "Chauvinistic",
+          "ControlRating": "",
+          "Points": "-",
+          1.0,
+          "Ref": "B164",
+          "Notes": ""
         },
         {
-          "idkey": "217",
-          "name": "Careful",
-          "control_rating": "",
-          "points": "-1",
-          "ref": "B164",
-          "notes": ""
+          "Idkey": "10773",
+          "Name": "wears chains",
+          "ControlRating": "",
+          "Points": "-",
+          1.0,
+          "Ref": "",
+          "Notes": ""
+        }
+      ],
+      "RepeatingDisadvantages": [
+        {
+          "Idkey": "10758",
+          "Name": "Bad Temper",
+          "TraitLevel": "1",
+          "ControlRating": "12",
+          "Points": "-",
+          10.0,
+          "Ref": "B124",
+          "Notes": "12 or less, *1"
         },
         {
-          "idkey": "169",
-          "name": "Will use whatever provides upper hand",
-          "control_rating": "",
-          "points": "-1",
-          "ref": "B163",
-          "notes": ""
-        }
-      ],
-      "repeating_disadvantages": [
-        {
-          "idkey": "159",
-          "name": "Addiction (Alcohol) (Cheap)",
-          "trait_level": "1",
-          "control_rating": "12",
-          "points": "-10",
-          "ref": "B122",
-          "notes": "Modifiers:\nEffect: Incapacitating, 10\nLegality: Legal, +5"
+          "Idkey": "10769",
+          "Name": "Enemy (Police)",
+          "TraitLevel": "1",
+          "ControlRating": "",
+          "Points": "-",
+          10.0,
+          "Ref": "B135",
+          "Notes": "Small group (3-5 people)\nPolice\n9 or less, *1\nHunter, *1"
         },
         {
-          "idkey": "164",
-          "name": "Code of Honor (Professional)",
-          "trait_level": "1",
-          "control_rating": "",
-          "points": "-5",
-          "ref": "B127",
-          "notes": ""
-        }
-      ],
-      "repeating_racial": [
-        {
-          "idkey": "",
-          "name": "Bad Temper",
-          "trait_level": "",
-          "control_rating": "12",
-          "points": "-5",
-          "ref": "",
-          "notes": ""
+          "Idkey": "10760",
+          "Name": "Greed",
+          "TraitLevel": "1",
+          "ControlRating": "12",
+          "Points": "-",
+          15.0,
+          "Ref": "B137",
+          "Notes": "12 or less, *1"
         },
         {
-          "idkey": "",
-          "name": "Strong Will",
-          "trait_level": "1",
-          "control_rating": "",
-          "points": 5,
-          "ref": "",
-          "notes": ""
+          "Idkey": "10762",
+          "Name": "Reputation (Gang Leader)",
+          "TraitLevel": "2",
+          "ControlRating": "",
+          "Points": "-",
+          1.0,
+          "Ref": "B27",
+          "Notes": "Gang Leader\n7 or less, *1/3\nLarge class, *1/2"
         }
       ],
-      "repeating_skills": [
+      "RepeatingRacial": [],
+      "RepeatingSkills": [
         {
-          "idkey": "",
-          "name": "Administration",
-          "tl": "",
-          "base": "IQ",
-          "difficulty": "A",
-          "bonus": 0,
-          "points": 1,
-          "use_wildcard_points": 0,
-          "use_normal_points": 1,
-          "wildcard_skill_points": 1,
-          "ref": "B174",
-          "skill_mod_notes": "",
-          "notes": ""
+          "Idkey": "10784",
+          "Name": "Area Knowledge (local)",
+          "Tl": "",
+          "Base": "@{intelligence}",
+          "Difficulty": "E",
+          "Bonus": 0.0,
+          "Points": 2.0,
+          "Skill": 11.0,
+          "Ref": "B176",
+          "SkillModNotes": "",
+          "Notes": "local"
         },
         {
-          "idkey": "",
-          "name": "Brawling",
-          "tl": "",
-          "base": "DX",
-          "difficulty": "E",
-          "bonus": 0,
-          "points": 4,
-          "ref": "B174",
-          "skill_mod_notes": "",
-          "notes": ""
-        }
-      ],
-      "repeating_techniquesrevised": [
-        {
-          "idkey": "",
-          "name": "Elbow Punch",
-          "parent": "Brawling",
-          "base_level": 14,
-          "default": "-2",
-          "max_modifier": 2,
-          "difficulty": "Hard",
-          "skill_modifier": 0,
-          "points": 2,
-          "ref": "",
-          "skill_mod_notes": "",
-          "notes": ""
-        }
-      ],
-      "repeating_defense": [
-        {
-          "idkey": "",
-          "name": "Punch",
-          "type": "Unarmed Parry",
-          "info": "",
-          "skill": 10,
-          "skill_mod": 0,
-          "defense_mod_reason": "",
-          "info_description": ""
+          "Idkey": "10753",
+          "Name": "Brawling",
+          "Tl": "",
+          "Base": "@{dexterity}",
+          "Difficulty": "E",
+          "Bonus": 0.0,
+          "Points": 4.0,
+          "Skill": 14.0,
+          "Ref": "B182",
+          "SkillModNotes": "",
+          "Notes": "Notes: Calculated damage takes into account bonuses from Teeth, Weak Bite, Claws, and skill level. You may add the modifier \"Has Gauntlets/Brass Knuckles\" or \"Has Boots\" to apply the +1 damage to Punch or Kick, as appropriate."
         },
         {
-          "idkey": "",
-          "name": "Brawling (Punch)",
-          "type": "Unarmed Parry",
-          "info": "",
-          "skill": 10,
-          "skill_mod": 0,
-          "defense_mod_reason": "",
-          "info_description": ""
-        }
-      ],
-      "repeating_melee": [
-        {
-          "idkey": "13",
-          "name": "Bite",
-          "damage": "1d6-1",
-          "type": "cr",
-          "reach": "c",
-          "skill": 14,
-          "reason_for_mod": "",
-          "armor_divisor": 1,
-          "notes": ""
-        }
-      ],
-      "repeating_ranged": [
-        {
-          "idkey": "",
-          "name": "Holdout Pistol, 7.5mmCLP",
-          "damage": "2d6",
-          "type": "pi",
-          "acc": "1",
-          "range": "100/1200",
-          "rof": "3",
-          "shots": "18+1(3)/0.2",
-          "bulk": "-1",
-          "recoil": "2",
-          "skill": 15,
-          "reason_for_mod": "",
-          "malfunction": "17",
-          "malfunction_verify": true,
-          "malfunction_very_reliable": true,
-          "armor_divisor": 0.5,
-          "notes": ""
-        }
-      ],
-      "repeating_item": [
-        {
-          "idkey": "",
-          "name": "7mmCL Conventional Ammunition",
-          "tl": "9",
-          "legality_class": "3",
-          "ref": "UT139",
-          "count": 16,
-          "cost": 0.54,
-          "weight": 0.027,
-          "notes": ""
+          "Idkey": "10780",
+          "Name": "Carousing",
+          "Tl": "",
+          "Base": "@{health}",
+          "Difficulty": "E",
+          "Bonus": 0.0,
+          "Points": 2.0,
+          "Skill": 13.0,
+          "Ref": "B183",
+          "SkillModNotes": "",
+          "Notes": ""
         },
         {
-          "idkey": "",
-          "name": "Antitoxin Kit",
-          "tl": "6",
-          "legality_class": "",
-          "ref": "B289",
-          "count": 1,
-          "cost": 25,
-          "weight": 0.5,
-          "notes": "Alcohol\n\nTL:6 Notes: Antidote for specific poison. 10 uses."
+          "Idkey": "10776",
+          "Name": "Connoisseur (Music)",
+          "Tl": "",
+          "Base": "@{intelligence}",
+          "Difficulty": "A",
+          "Bonus": 0.0,
+          "Points": 3.0,
+          "Skill": 11.0,
+          "Ref": "B185",
+          "SkillModNotes": "",
+          "Notes": "Music"
         },
         {
-          "idkey": "",
-          "name": "Cell Phone",
-          "tl": "8",
-          "legality_class": "",
-          "ref": "B288",
-          "count": 1,
-          "cost": 250,
-          "weight": 0.25,
-          "notes": "TL:8 Notes: Only works in some areas, $20/month fee. 10hrs."
+          "Idkey": "10777",
+          "Name": "Dancing",
+          "Tl": "",
+          "Base": "@{dexterity}",
+          "Difficulty": "A",
+          "Bonus": 0.0,
+          "Points": 1.0,
+          "Skill": 11.0,
+          "Ref": "B187",
+          "SkillModNotes": "",
+          "Notes": ""
         },
         {
-          "idkey": "",
-          "name": "Holdout Pistol, 7.5mmCLP",
-          "tl": "9",
-          "legality_class": "3",
-          "ref": "UT137",
-          "count": 1,
-          "cost": 240,
-          "weight": 1,
-          "notes": "HUD +1 ACC \u003c 300 yards. Laser Sight +1 Skill \u003c 1/2D Range. Recognition Grip. Diagnostic Chip +1 Repair\n\nTL:9 LC:3 Ammo:0.2 lb. Damage:2d pi Acc:1 Range:100/1200 RoF:3 Shots:18+1(3) ST:6 Bulk:-1 Rcl:2 Skill:Guns (Pistol"
+          "Idkey": "10781",
+          "Name": "Forced Entry",
+          "Tl": "",
+          "Base": "@{dexterity}",
+          "Difficulty": "E",
+          "Bonus": 0.0,
+          "Points": 2.0,
+          "Skill": 13.0,
+          "Ref": "B196",
+          "SkillModNotes": "",
+          "Notes": ""
+        },
+        {
+          "Idkey": "10775",
+          "Name": "Guns (Pistol)",
+          "Tl": "8",
+          "Base": "@{dexterity}",
+          "Difficulty": "E",
+          "Bonus": 0.0,
+          "Points": 4.0,
+          "Skill": 14.0,
+          "Ref": "B198",
+          "SkillModNotes": "",
+          "Notes": "uns/TL8 (Pistol"
+        },
+        {
+          "Idkey": "10752",
+          "Name": "Innate Attack (Projectile)",
+          "Tl": "",
+          "Base": "@{dexterity}",
+          "Difficulty": "E",
+          "Bonus": 1.0,
+          "Points": 12.0,
+          "Skill": 17.0,
+          "Ref": "B201",
+          "SkillModNotes": "+1 from 'Body Control Talent 1 (Innate Attack (Projectile), +0)'",
+          "Notes": "Projectile"
+        },
+        {
+          "Idkey": "10782",
+          "Name": "Intimidation",
+          "Tl": "",
+          "Base": "10",
+          "Difficulty": "A",
+          "Bonus": 0.0,
+          "Points": 4.0,
+          "Skill": 13.0,
+          "Ref": "B202",
+          "SkillModNotes": "",
+          "Notes": ""
+        },
+        {
+          "Idkey": "10798",
+          "Name": "Leadership",
+          "Tl": "",
+          "Base": "@{intelligence}",
+          "Difficulty": "A",
+          "Bonus": 2.0,
+          "Points": 4.0,
+          "Skill": 13.0,
+          "Ref": "B204",
+          "SkillModNotes": "+2 from 'Charisma 2'",
+          "Notes": ""
+        },
+        {
+          "Idkey": "10778",
+          "Name": "Musical Instrument (Guitar)",
+          "Tl": "",
+          "Base": "@{intelligence}",
+          "Difficulty": "H",
+          "Bonus": 0.0,
+          "Points": 12.0,
+          "Skill": 12.0,
+          "Ref": "B211",
+          "SkillModNotes": "",
+          "Notes": "Guitar"
+        },
+        {
+          "Idkey": "13357",
+          "Name": "Navigation (Land)",
+          "Tl": "8",
+          "Base": "@{intelligence}",
+          "Difficulty": "A",
+          "Bonus": 0.0,
+          "Points": 2.0,
+          "Skill": 10.0,
+          "Ref": "B211",
+          "SkillModNotes": "",
+          "Notes": "avigation/TL8 (Land"
+        },
+        {
+          "Idkey": "13175",
+          "Name": "Shield (Force)",
+          "Tl": "",
+          "Base": "@{dexterity}",
+          "Difficulty": "E",
+          "Bonus": 0.0,
+          "Points": 2.0,
+          "Skill": 13.0,
+          "Ref": "B220",
+          "SkillModNotes": "",
+          "Notes": "Force"
+        },
+        {
+          "Idkey": "10779",
+          "Name": "Singing",
+          "Tl": "",
+          "Base": "@{health}",
+          "Difficulty": "E",
+          "Bonus": 0.0,
+          "Points": 2.0,
+          "Skill": 13.0,
+          "Ref": "B220",
+          "SkillModNotes": "",
+          "Notes": ""
+        },
+        {
+          "Idkey": "10783",
+          "Name": "Streetwise",
+          "Tl": "",
+          "Base": "@{intelligence}",
+          "Difficulty": "A",
+          "Bonus": 0.0,
+          "Points": 8.0,
+          "Skill": 12.0,
+          "Ref": "B223",
+          "SkillModNotes": "",
+          "Notes": ""
+        },
+        {
+          "Idkey": "13174",
+          "Name": "Wrestling",
+          "Tl": "",
+          "Base": "@{dexterity}",
+          "Difficulty": "A",
+          "Bonus": 0.0,
+          "Points": 1.0,
+          "Skill": 11.0,
+          "Ref": "B228",
+          "SkillModNotes": "",
+          "Notes": ""
         }
       ],
-      "repeating_spells": [
+      "RepeatingTechniquesrevised": [
         {
-          "idkey": "",
-          "name": "Air Jet",
-          "difficulty": "H",
-          "spell_modifier": 2,
-          "points": 2,
-          "spell_resisted_by": "",
-          "duration": "1 sec.",
-          "cost": "1 to 3/S",
-          "casttime": "1 sec.",
-          "maintain": "",
-          "spell_class": "Regular",
-          "spell_college": "Air",
-          "spell_college_secondary": "",
-          "spell_mod_notes": "",
-          "spell_notes": "Prereq Count: 3 Prerequisites: Shape Air\n\nNeeds: Shape Air, ST:Magery = 0 | PE:Charms ([Spell]) | PE:Charms (%SpellsList%) | PE:Charms (Air Jet)"
+          "Idkey": "13172",
+          "Name": "Aggressive Parry (Brawling)",
+          "Parent": "Brawling",
+          "BaseLevel": "10",
+          "Default": "-",
+          1.0,
+          "MaxModifier": 0.0,
+          "Difficulty": "H",
+          "SkillModifier": 0.0,
+          "Points": 2.0,
+          "Skill": 11.0,
+          "Ref": "MA65",
+          "SkillModNotes": "",
+          "Notes": "Brawling"
         },
         {
-          "idkey": "",
-          "name": "Fireball",
-          "difficulty": "H",
-          "spell_modifier": 0,
-          "points": 2,
-          "spell_resisted_by": "",
-          "duration": "Instant",
-          "cost": "1 to Magery#",
-          "casttime": "1 to 3 sec.",
-          "maintain": "",
-          "spell_class": "Missile",
-          "spell_college": "Fire",
-          "spell_college_secondary": "",
-          "spell_mod_notes": "",
-          "spell_notes": "Prereq Count: 3 Prerequisites: Magery 1, Create Fire, Shape Fire\n\nNeeds: (AD:Magery 0 | ST:Magery 0 = 1), (AD:Magery = 1, ST:Magery = 1 | ST:Magery Fire = 1), Create Fire, Shape Fire, ST:Magery = 0 | PE:Charms ([Spell]) | PE:Charms (%SpellsList%) | PE:Charms (Fireball),"
+          "Idkey": "13173",
+          "Name": "Arm Lock (Wrestling)",
+          "Parent": "Wrestling",
+          "BaseLevel": "11",
+          "Default": 0.0,
+          "MaxModifier": 4.0,
+          "Difficulty": "A",
+          "SkillModifier": 0.0,
+          "Points": 2.0,
+          "Skill": 13.0,
+          "Ref": "MA65, B230",
+          "SkillModNotes": "",
+          "Notes": "Wrestling"
         }
       ],
-      "final_values": {
-        "combat_reflexes": true
-      }
+      "RepeatingDefense": [
+        {
+          "Idkey": "10704_power_dodge",
+          "Name": "Body Control Talent (Power Dodge)",
+          "Type": "Power Dodge",
+          "Info": "",
+          "Skill": 9.0,
+          "SkillMod": 0.0,
+          "DefenseModReason": "",
+          "InfoDescription": ""
+        },
+        {
+          "Idkey": "10704_power_block",
+          "Name": "Body Control Talent (Power Block/Physical)",
+          "Type": "Power Block",
+          "Info": "",
+          "Skill": 9.0,
+          "SkillMod": 0.0,
+          "DefenseModReason": "",
+          "InfoDescription": ""
+        },
+        {
+          "Idkey": "10704_power_block_mental",
+          "Name": "Body Control Talent (Power Block/Mental)",
+          "Type": "Power Block Mental",
+          "Info": "",
+          "Skill": 9.0,
+          "SkillMod": 0.0,
+          "DefenseModReason": "",
+          "InfoDescription": ""
+        },
+        {
+          "Idkey": "10753_unarmed_parry",
+          "Name": "Brawling (Punch)",
+          "Type": "Unarmed Parry",
+          "Info": "",
+          "Skill": 11.0,
+          "SkillMod": 0.0,
+          "DefenseModReason": "",
+          "InfoDescription": ""
+        },
+        {
+          "Idkey": "10613_unarmed_parry",
+          "Name": "Punch",
+          "Type": "Unarmed Parry",
+          "Info": "",
+          "Skill": 11.0,
+          "SkillMod": 0.0,
+          "DefenseModReason": "",
+          "InfoDescription": ""
+        },
+        {
+          "Idkey": "13175_block",
+          "Name": "Shield (Force)",
+          "Type": "Block",
+          "Info": "",
+          "Skill": 10.0,
+          "SkillMod": 0.0,
+          "DefenseModReason": "",
+          "InfoDescription": ""
+        }
+      ],
+      "RepeatingMelee": [
+        {
+          "Idkey": "13172_aggressiveparry_",
+          "Name": "Aggressive Parry (Brawling)",
+          "Damage": "2d6-2",
+          "Type": "cr",
+          "Reach": "C",
+          "Skill": 11.0,
+          "ArmorDivisor": 1.0,
+          "Notes": ""
+        },
+        {
+          "Idkey": "10525_bite_bite",
+          "Name": "Bite",
+          "Damage": "2d6+1",
+          "Type": "cr",
+          "Reach": "C",
+          "Skill": 14.0,
+          "ArmorDivisor": 1.0,
+          "Notes": "{Brawling (p. B182) increases all unarmed damage; Claws (p. B42) and Karate (p. B203) improve damage with punches and kicks (Claws don't affect damage with brass knuckles or boots); and Boxing (p. B182) improves punching damage.}"
+        },
+        {
+          "Idkey": "10753_brawling_punch",
+          "Name": "Brawling (Punch)",
+          "Damage": "2d6+1",
+          "Type": "cr",
+          "Reach": "C",
+          "Skill": 14.0,
+          "ArmorDivisor": 1.0,
+          "Notes": ""
+        },
+        {
+          "Idkey": "10753_brawling_bite",
+          "Name": "Brawling (Bite)",
+          "Damage": "2d6+1",
+          "Type": "cr",
+          "Reach": "C",
+          "Skill": 14.0,
+          "ArmorDivisor": 1.0,
+          "Notes": ""
+        },
+        {
+          "Idkey": "10753_brawling_kick",
+          "Name": "Brawling (Kick)",
+          "Damage": "2d6+2",
+          "Type": "cr",
+          "Reach": "C,1",
+          "Skill": 12.0,
+          "ArmorDivisor": 1.0,
+          "Notes": "{If you miss with a kick, roll vs. DX to avoid falling.}"
+        },
+        {
+          "Idkey": "13176_forceshield_bash",
+          "Name": "Force Shield (Bash)",
+          "Damage": "2d6",
+          "Type": "cr",
+          "Reach": "1",
+          "Skill": 13.0,
+          "ArmorDivisor": 1.0,
+          "Notes": "{Worn on the wrist, leaving the hand free.}"
+        },
+        {
+          "Idkey": "13176_forceshield_rush",
+          "Name": "Force Shield (Rush)",
+          "Damage": "slam+3",
+          "Type": "cr",
+          "Reach": "1",
+          "Skill": 13.0,
+          "ArmorDivisor": 1.0,
+          "Notes": "{Worn on the wrist, leaving the hand free.}"
+        },
+        {
+          "Idkey": "10558_kick_kick",
+          "Name": "Kick",
+          "Damage": "2d6+2",
+          "Type": "cr",
+          "Reach": "C,1",
+          "Skill": 12.0,
+          "ArmorDivisor": 1.0,
+          "Notes": "{Brawling (p. B182) increases all unarmed damage; Claws (p. B42) and Karate (p. B203) improve damage with punches and kicks (Claws don't affect damage with brass knuckles or boots); and Boxing (p. B182) improves punching damage.}"
+        },
+        {
+          "Idkey": "10613_punch_punch",
+          "Name": "Punch",
+          "Damage": "2d6+1",
+          "Type": "cr",
+          "Reach": "C",
+          "Skill": 14.0,
+          "ArmorDivisor": 1.0,
+          "Notes": "{Brawling (p. B182) increases all unarmed damage; Claws (p. B42) and Karate (p. B203) improve damage with punches and kicks (Claws don't affect damage with brass knuckles or boots); and Boxing (p. B182) improves punching damage.}"
+        }
+      ],
+      "RepeatingRanged": [
+        {
+          "Idkey": "10720_crossbow_primary",
+          "Name": "Crossbow (Armor Piercing) (Primary)",
+          "Damage": "3d6",
+          "Type": "imp",
+          "Acc": "2",
+          "Range": "100/200",
+          "Rof": "1",
+          "Shots": "",
+          "Bulk": "",
+          "Recoil": "1",
+          "Skill": 17.0,
+          "Malfunction": "",
+          "MalfunctionVerify": false,
+          "MalfunctionVeryReliable": false,
+          "ArmorDivisor": 2.0,
+          "Notes": ""
+        },
+        {
+          "Idkey": "10730_crossbow_primary",
+          "Name": "Crossbow (Explosive) (Primary)",
+          "Damage": "3d6",
+          "Type": "cr dkb ex/2",
+          "Acc": "2",
+          "Range": "200",
+          "Rof": "1",
+          "Shots": "n/a",
+          "Bulk": "",
+          "Recoil": "1",
+          "Skill": 17.0,
+          "Malfunction": "",
+          "MalfunctionVerify": false,
+          "MalfunctionVeryReliable": false,
+          "ArmorDivisor": 1.0,
+          "Notes": ""
+        },
+        {
+          "Idkey": "10786_revolver357m_",
+          "Name": "Revolver, .357M",
+          "Damage": "3d6-1",
+          "Type": "pi",
+          "Acc": "2",
+          "Range": "185/2000",
+          "Rof": "3",
+          "Shots": "6(3i)",
+          "Bulk": "-2",
+          "Recoil": "3",
+          "Skill": 15.0,
+          "Malfunction": "17",
+          "MalfunctionVerify": false,
+          "MalfunctionVeryReliable": false,
+          "ArmorDivisor": 1.0,
+          "Notes": ""
+        }
+      ],
+      "RepeatingItem": [
+        {
+          "Idkey": "10833",
+          "Name": "Advanced Body Armor",
+          "Tl": "8",
+          "LegalityClass": "2",
+          "Ref": "HT66",
+          "Count": 1.0,
+          "Cost": 4600.0,
+          "Weight": 17.0,
+          "Notes": "Signature Gear, +0\nTL:8 LC:2 DR:35/5* Location:torso Notes:[1] Concealable as or under clothing. [5] Use the lower DR versus crushing attacks only."
+        },
+        {
+          "Idkey": "10790",
+          "Name": "Boots, Steel-Toed",
+          "Tl": "6",
+          "LegalityClass": "4",
+          "Ref": "HT68",
+          "Count": 1.0,
+          "Cost": 100.0,
+          "Weight": 4.0,
+          "Notes": "TL:6 LC:4 DR:6/2 Location:feet Notes:[1] Concealable as or under clothing. [2] Give +1 to kicking damage (p. B271). [4] Split DR: use the first, higher DR when - in the GM's opinion - the boot's steel toe box would protect (e. g. , dropping an item on the foot or crushing the toes in heavy machinery) or when an attack on the foot hits the toe (2/6 protection); use the second, lower DR against all other attacks."
+        },
+        {
+          "Idkey": "13358",
+          "Name": "Compass",
+          "Tl": "6",
+          "LegalityClass": "",
+          "Ref": "B288",
+          "Count": 1.0,
+          "Cost": 50.0,
+          "Weight": 0.0,
+          "Notes": "TL:6 Notes: +1 to Navigation skill"
+        },
+        {
+          "Idkey": "13176",
+          "Name": "Force Shield",
+          "Tl": "^",
+          "LegalityClass": "3",
+          "Ref": "B273, B287",
+          "Count": 1.0,
+          "Cost": 1500.0,
+          "Weight": 0.5,
+          "Notes": "TL:^ LC:3 DB:3 Dam:thr cr Reach:1 Parry:No ST:-- DR:100 HP:-- Skill:Shield (Force) Notes: [3,5] Also available as a buckler. You can ready a buckler in one turn and drop it as a free action, just like a weapon - but it always occupies one hand, and it does not allow a shield rush. Use Shield (Buckler) instead of regular shield skill. No effect on statistics. Worn on the wrist, leaving the hand free. DR is hardened (treat as Hardened enhancement, p. B47)."
+        },
+        {
+          "Idkey": "13355",
+          "Name": "Holster, Belt",
+          "Tl": "5",
+          "LegalityClass": "",
+          "Ref": "B289",
+          "Count": 1.0,
+          "Cost": 1180.4,
+          "Weight": 7.62,
+          "Notes": "TL:5 Notes: Fits most pistols."
+        },
+        {
+          "Idkey": "10788",
+          "Name": "Laser Sight",
+          "Tl": "8",
+          "LegalityClass": "",
+          "Ref": "B289",
+          "Count": 1.0,
+          "Cost": 100.0,
+          "Weight": 0.0,
+          "Notes": "TL:8 Notes: +1 to skill, see Laser Sights (p. B412)"
+        },
+        {
+          "Idkey": "10792",
+          "Name": "Personal Basics",
+          "Tl": "0",
+          "LegalityClass": "",
+          "Ref": "B288",
+          "Count": 1.0,
+          "Cost": 5.0,
+          "Weight": 1.0,
+          "Notes": "TL:0 Notes: Minimum gear for camping: -2 to any Survival roll without it. Includes utensils, tinderbox or flint and steel, towel, etc., as TL permits."
+        },
+        {
+          "Idkey": "10786",
+          "Name": "Revolver, .357M",
+          "Tl": "7",
+          "LegalityClass": "3",
+          "Ref": "B278",
+          "Count": 1.0,
+          "Cost": 1100.0,
+          "Weight": 3.6,
+          "Notes": "Rugged, *2\nReceives Skill Bonus, +1, +0\nTL:7 LC:3 Damage:3d-1 pi Acc:2 Range:185/2000 RoF:3 Shots:6(3i) ST:10 Bulk:-2 Rcl:3 Skill:Guns (Pistol)"
+        },
+        {
+          "Idkey": "13356",
+          "Name": "Revolver, .357M (Ammunition)",
+          "Tl": "7",
+          "LegalityClass": "3",
+          "Ref": "",
+          "Count": 12.0,
+          "Cost": 50.4,
+          "Weight": 2.52,
+          "Notes": "Ammunition"
+        }
+      ],
+      "RepeatingSpells": []
     }
   ]
 }

--- a/ExportToRoll20/AssemblyInfo.cs
+++ b/ExportToRoll20/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.8")]
+[assembly: AssemblyFileVersion("1.0.1.8")]

--- a/ExportToRoll20/ConvertToRoll20Character.cs
+++ b/ExportToRoll20/ConvertToRoll20Character.cs
@@ -746,7 +746,7 @@ namespace ExportToRoll20
                 {
                     Idkey = template.IDKey.ToString(),
                     Name = template.FullName,
-                    Points = 0,
+                    Points = template.PreModsPoints,
                     Ref = template.get_TagItem("ref"),
                     Notes = notes
                 };
@@ -1270,13 +1270,23 @@ namespace ExportToRoll20
                         }
                     }
 
+                    // if it is a parent, set the points to zero
+                    var childIds =  trait.get_TagItem("childkeylist").Split(seperators, StringSplitOptions.RemoveEmptyEntries);
+
+                    double spellPoints = trait.Points;
+
+                    if (childIds.Length > 0)
+                    {
+                        spellPoints = 0;
+                    }
+
                     var spell = new RepeatingSpell()
                     {
                         Idkey = trait.IDKey.ToString(),
                         Name = trait.FullName,
                         Difficulty = GetDifficultyForSkill(trait.SkillType),
                         SpellModifier = GetTraitModifier(trait),
-                        Points = trait.Points,
+                        Points = spellPoints,
                         SpellResistedBy = resistedBy,
                         Duration = trait.get_TagItem("duration"),
                         Cost = trait.get_TagItem("castingcost"),
@@ -1554,13 +1564,6 @@ namespace ExportToRoll20
         {
             var notes = new ArrayList();
 
-            var userNotes = trait.get_TagItem("usernotes").Trim();
-
-            if (!string.IsNullOrEmpty(userNotes))
-            {
-                notes.Add(userNotes);
-            }
-
             if (trait.DisplayName.Length > 0 && trait.DisplayName.Contains("("))
             {
                 // Contact (Effective Skill 12; Rival Gang; 9 or less, *1; Somewhat Reliable, *1)
@@ -1596,23 +1599,42 @@ namespace ExportToRoll20
 
                 if (nameParts.Length > 0)
                 {
-                    notes.Add(string.Join("\n", nameParts));
+                    notes.Add("**Features**:\n" + string.Join("\n", nameParts) + "\n");
                 }
 
             }
 
-            if (!string.IsNullOrEmpty(trait.Notes.Trim()))
+            // --------- User Notes ------------
+            var userNotes = trait.GetNotes(true);
+
+            if (!string.IsNullOrEmpty(userNotes))
             {
-                notes.Add(trait.Notes);
+                notes.Add("**User Notes:**\n" + userNotes);
             }
 
+            // --------- Description ------------
             var tagDescription = trait.get_TagItem("description").Trim();
 
             if (!string.IsNullOrEmpty(tagDescription))
             {
-                notes.Add(tagDescription);
+                // convert to plain text
+                tagDescription = modHelperFunctions.RTFtoPlainText(tagDescription);
+
+                notes.Add("**Description:**\n" + tagDescription);
             }
 
+            // --------- VTT Notes ------------
+            var vttNotes = trait.get_TagItem("vttnotes").Trim();
+
+            if (!string.IsNullOrEmpty(vttNotes))
+            {
+                // convert to plain text
+                vttNotes = modHelperFunctions.RTFtoPlainText(vttNotes);
+
+                notes.Add("**VTT Notes:**\n" + vttNotes);
+            }
+
+            // combine everything
             string noteDescription = string.Join("\n", notes.ToArray());
 
             return noteDescription;

--- a/ExportToRoll20/ConvertToRoll20Character.cs
+++ b/ExportToRoll20/ConvertToRoll20Character.cs
@@ -875,7 +875,7 @@ namespace ExportToRoll20
         {
             string baseAttribute = "10";
 
-            switch (stepoff)
+            switch (stepoff.ToUpper())
             {
                 case "ST":
                     baseAttribute = "@{strength}";

--- a/ExportToRoll20/ExportToRoll20.cs
+++ b/ExportToRoll20/ExportToRoll20.cs
@@ -27,7 +27,7 @@ namespace ExportToRoll20
     {
         private const string PLUGIN_NAME = "Export Character to Roll20";
         private const string PLUGIN_DESCRIPTION = "Export Character to a json file to import into Roll20. For more informaiton see: https://github.com/MadCoder253/GCA5Roll20Exporter";
-        private const string PLUGIN_VERSION = "1.0.0.0";
+        private const string PLUGIN_VERSION = "1.0.1.8";
 
         public event IExportSheet.RequestRunSpecificOptionsEventHandler RequestRunSpecificOptions;
 

--- a/ExportToRoll20/ExportToRoll20.csproj
+++ b/ExportToRoll20/ExportToRoll20.csproj
@@ -63,8 +63,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(ProjectDir)$(OutDir)$(TargetFileName)" "C:\Users\kfoub\OneDrive\Documents\GURPS Character Assistant 5\plugins\ExportToRoll20\$(TargetFileName)"
-copy /Y "$(ProjectDir)$(OutDir)$(ProjectName).pdb" "C:\Users\kfoub\OneDrive\Documents\GURPS Character Assistant 5\plugins\ExportToRoll20\$(ProjectName).pdb"
-copy /Y "$(SolutionDir)\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll" "C:\Users\kfoub\OneDrive\Documents\GURPS Character Assistant 5\plugins\ExportToRoll20\Newtonsoft.Json.dll"</PostBuildEvent>
+    <PostBuildEvent>copy /Y "$(ProjectDir)\ExportToRoll20.cs" "C:\ProgramData\Steve Jackson Games\GURPS Character Assistant 5\plugins\ExportToRoll20\ExportToRoll20.cs"
+copy /Y "$(ProjectDir)\ConvertToRoll20Character.cs" "C:\ProgramData\Steve Jackson Games\GURPS Character Assistant 5\plugins\ExportToRoll20\ConvertToRoll20Character.cs"
+copy /Y "$(ProjectDir)\AssemblyInfo.cs" "C:\ProgramData\Steve Jackson Games\GURPS Character Assistant 5\plugins\ExportToRoll20\AssemblyInfo.cs"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/ExportToRoll20/Properties/AssemblyInfo.cs
+++ b/ExportToRoll20/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.8")]
+[assembly: AssemblyFileVersion("1.0.1.8")]

--- a/README.md
+++ b/README.md
@@ -7,3 +7,28 @@ GCA5 Plugin for Exporting to Roll20
 Initial source code provided by WoodmanX
 
 [GCA5FantasyGroundsExporter](https://github.com/WoodmanX/GCA5FantasyGroundsExporter)
+
+## Versions
+
+### 1.0.1.0
+
+- Fix bug when checking base skill trait by capitalizing the value for `stepoff` value.
+- Some templates have a base cost that is not reflected in the list of traits. Update template to get PreModsPoints.
+- Added VTT Notes.
+- Implemented modHelperFunctions.RTFtoPlainText() for notes.
+- If a spell is a parent, set the points to zero. Temporary fix until parent/child relationships are handled.
+
+## File Locations
+
+GCA5 Plugin Location: C:\ProgramData\Steve Jackson Games\GURPS Character Assistant 5\plugins\ExportToRoll20
+
+## Development
+
+### Deploying to GCA5
+
+- Make sure GCA5 is not running
+- Build or Rebuild the Project
+  - The post-build macro will copy source code files to the `GCA5 Plugin Location`.
+- Start GCA%
+  - You can test your updates
+- Hint: Edit `~\ExportToRoll20\ExportToRoll20.cs` and change the value for `PLUGIN_VERSION`. This helps verify the code was copied over correctly.


### PR DESCRIPTION
- Fix bug when checking base skill trait by capitalizing the value for `stepoff` value.
- Some templates have a base cost that is not reflected in the list of traits. Update template to get PreModsPoints.
- Added VTT Notes.
- Implemented modHelperFunctions.RTFtoPlainText() for notes.
- If a spell is a parent, set the points to zero. Temporary fix until parent/child relationships are handled.