### PR TITLE
- Add new fields to the export for Roll20 character sheets, including:

### DIFF
--- a/ExportToRoll20/AssemblyInfo.cs
+++ b/ExportToRoll20/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Wandering Monsters")]
 [assembly: AssemblyProduct("Export Character to Roll20")]
-[assembly: AssemblyCopyright("Copyright ©  2022 Wandering Monsters")]
+[assembly: AssemblyCopyright("Copyright ©  2026 Wandering Monsters")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.10")]
-[assembly: AssemblyFileVersion("1.0.1.10")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/ExportToRoll20/ConvertToRoll20Character.cs
+++ b/ExportToRoll20/ConvertToRoll20Character.cs
@@ -7,6 +7,8 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
+using System.Xml;
+using ExtensionMethod;
 using GCA5.Interfaces;
 using GCA5Engine;
 using Microsoft.VisualBasic;
@@ -102,16 +104,19 @@ namespace ExportToRoll20
                 roll20Character.Age = currentCharacter.Age;
                 roll20Character.Height = currentCharacter.Height;
 
-                double weight = 0;
-                result = double.TryParse(currentCharacter.Weight, out weight);
-                if (result)
-                {
-                    roll20Character.Weight = weight;
-                }
-                else
-                {
-                    roll20Character.Weight = 0;
-                }
+                // biographical data
+                roll20Character.Gender = GetCharacterTagValue(currentCharacter, "bio_gender");
+                roll20Character.BirthDate = GetCharacterTagValue(currentCharacter, "bio_dob");
+                roll20Character.BirthPlace = GetCharacterTagValue(currentCharacter, "bio_pob");
+                roll20Character.HomeWorld = GetCharacterTagValue(currentCharacter, "bio_homeworld");
+                roll20Character.Gravity = ParseSanitizedNumber(GetCharacterTagValue(currentCharacter, "bio_homegravity"), 1);
+                roll20Character.Handedness = GetCharacterTagValue(currentCharacter, "bio_handedness");
+                roll20Character.Build = GetCharacterTagValue(currentCharacter, "bio_build");
+                roll20Character.HairColor = GetCharacterTagValue(currentCharacter, "bio_haircolor");
+                roll20Character.EyeColor = GetCharacterTagValue(currentCharacter, "bio_eyecolor");
+                roll20Character.Family = GetCharacterTagValue(currentCharacter, "bio_family");
+
+                roll20Character.Weight = ParseSanitizedNumber(currentCharacter.Weight, 1);
 
                 roll20Character.Appearance = GetAppearanceScore(currentCharacter);
                 roll20Character.GeneralAppearance = currentCharacter.Appearance;
@@ -379,6 +384,79 @@ namespace ExportToRoll20
 
             return roll20Character;
 
+        }
+
+        protected string GetCharacterTagValue(GCACharacter currentCharacter, string tagName)
+        {
+            string value = currentCharacter.get_TagItem(tagName);
+            if (!string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            try
+            {
+                string characterXml = currentCharacter.ToXmlString();
+                if (string.IsNullOrEmpty(characterXml))
+                {
+                    return string.Empty;
+                }
+
+                XmlDocument doc = new XmlDocument();
+                doc.LoadXml(characterXml);
+
+                XmlNodeList extendedTags = doc.GetElementsByTagName("extendedtag");
+                foreach (XmlNode extendedTag in extendedTags)
+                {
+                    string name = string.Empty;
+                    string tagValue = string.Empty;
+
+                    foreach (XmlNode child in extendedTag.ChildNodes)
+                    {
+                        if (string.Equals(child.LocalName, "tagname", StringComparison.OrdinalIgnoreCase))
+                        {
+                            name = child.InnerText;
+                        }
+                        else if (string.Equals(child.LocalName, "tagvalue", StringComparison.OrdinalIgnoreCase))
+                        {
+                            tagValue = child.InnerText;
+                        }
+                    }
+
+                    if (string.Equals(name, tagName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return tagValue;
+                    }
+                }
+
+                return string.Empty;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        protected double ParseSanitizedNumber(string value, double defaultValue)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return defaultValue;
+            }
+
+            string sanitizedValue = Regex.Replace(value, "[^0-9.]", "");
+            if (string.IsNullOrWhiteSpace(sanitizedValue))
+            {
+                return defaultValue;
+            }
+
+            double parsedValue;
+            if (!double.TryParse(sanitizedValue, out parsedValue))
+            {
+                return defaultValue;
+            }
+
+            return parsedValue;
         }
 
         public string GetReactions(GCACharacter currentCharacter)

--- a/ExportToRoll20/ExportToRoll20.cs
+++ b/ExportToRoll20/ExportToRoll20.cs
@@ -27,7 +27,7 @@ namespace ExportToRoll20
     {
         private const string PLUGIN_NAME = "Export to Roll20";
         private const string PLUGIN_DESCRIPTION = "Export Character to a json file to import into Roll20. For more informaiton see: https://github.com/MadCoder253/GCA5Roll20Exporter";
-        private const string PLUGIN_VERSION = "1.0.1.21";
+        private const string PLUGIN_VERSION = "1.1.0.0";
 
         public event IExportSheet.RequestRunSpecificOptionsEventHandler RequestRunSpecificOptions;
 

--- a/ExportToRoll20/Properties/AssemblyInfo.cs
+++ b/ExportToRoll20/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Wandering Monsters")]
 [assembly: AssemblyProduct("Export to Roll20")]
-[assembly: AssemblyCopyright("Copyright ©  2023 Wandering Monsters")]
+[assembly: AssemblyCopyright("Copyright ©  2026 Wandering Monsters")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.21")]
-[assembly: AssemblyFileVersion("1.0.1.21")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/ExportToRoll20/Roll20Character.cs
+++ b/ExportToRoll20/Roll20Character.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Reflection.Emit;
 
 namespace ExportToRoll20
 {
@@ -507,6 +509,19 @@ namespace ExportToRoll20
             Weight = 0;
             Appearance = 0;
             GeneralAppearance = "";
+
+            // background information
+            Gender = "";
+            BirthDate = "";
+            BirthPlace = "";
+            HomeWorld = "";
+            Gravity = 1.0;
+            Handedness = "";
+            Build = "";
+            HairColor = "";
+            EyeColor = "";
+            Family = "";
+
             StrengthMod = 0;
             StrengthPoints = 0;
             DexterityMod = 0;
@@ -631,6 +646,24 @@ namespace ExportToRoll20
         public double Appearance { get; set; } 
 
         public string GeneralAppearance { get; set; } 
+
+        public string BirthDate { get; set; }
+
+        public string BirthPlace { get; set; }
+
+        public string HomeWorld { get; set; }
+
+        public double Gravity { get; set; }
+
+        public string Handedness { get; set; }
+
+        public string Build { get; set; }
+
+        public string HairColor { get; set; }
+
+        public string EyeColor { get; set; }
+
+        public string Family { get; set; }
 
         public double StrengthMod { get; set; } 
 

--- a/GCA5Roll20Exporter.sln
+++ b/GCA5Roll20Exporter.sln
@@ -1,9 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.3.32519.111
+# Visual Studio Version 18
+VisualStudioVersion = 18.6.11822.322 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExportToRoll20", "ExportToRoll20\ExportToRoll20.csproj", "{39B43A45-F031-40EB-9FFE-96033FD28DF5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A2892F15-E159-40EE-94E0-681D13CB564C}"
+	ProjectSection(SolutionItems) = preProject
+		ExportToRoll20\compile.xml = ExportToRoll20\compile.xml
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@ Initial source code provided by WoodmanX
 
 ## Versions
 
+### 1.1.0.0
+
+6/6/2026
+
+- Add new fields to the export for Roll20 character sheets, including:
+  - `HomeWorld` from Biographical Data
+  - `Gravity` from Biographical Data
+  - `BirthDate` from Biographical Data
+  - `BirthPlace` from Biographical Data
+  - `Gender` from Biographical Data
+  - `Handedness` from Biographical Data
+  - `Build` from Biographical Data
+  - `HairColor` from Biographical Data
+  - `EyeColor` from Biographical Data
+  - `Family` from Biographical Data
+- Update weight import to strip out out string values and convert to a number.
+
 ### 1.0.1.21
 
 - Convert `GetTraitNotes(GCATrait trait)` code for extracting notes to use regex.


### PR DESCRIPTION
- Add new fields to the export for Roll20 character sheets, including:
  - `HomeWorld` from Biographical Data
  - `Gravity` from Biographical Data
  - `BirthDate` from Biographical Data
  - `BirthPlace` from Biographical Data
  - `Gender` from Biographical Data
  - `Handedness` from Biographical Data
  - `Build` from Biographical Data
  - `HairColor` from Biographical Data
  - `EyeColor` from Biographical Data
  - `Family` from Biographical Data
- Update weight import to strip out out string values and convert to a number.